### PR TITLE
Add PublishMarkdown plugin for writing feeds as Markdown documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ plugins:
     config:
       db: seen.db
 
-  - module: PublishConsole
+  - module: PublishMarkdown
+    config:
+      file: ~/notes/feeds.md
 ```
 
 ```sh
@@ -31,9 +33,11 @@ automatic -c my_recipe.yml
 ```
 
 Fetch some feeds, drop what you do not want, remember what you have already
-seen, and do something with the rest. Change the last plugin and the same
-pipeline downloads the images instead, or forwards them to Fluentd, or writes
-them to a database. Write your own plugin and it composes with all the others.
+seen, and write the rest into a Markdown file: readable by people, reusable by
+tools, ready to hand to an AI. Change the last plugin and the same pipeline
+prints to the terminal instead, or downloads the images, or forwards them to
+Fluentd, or writes them to a database. Write your own plugin and it composes
+with all the others.
 
 ---
 
@@ -67,6 +71,13 @@ twice, and send the result somewhere. Writing each such job as a script means
 writing the fetching, the filtering, the de-duplication and the retrying again
 every time.
 
+"Somewhere" is often a file. A Recipe that ends in `PublishMarkdown` leaves what
+it collected as a Markdown document: a person reads it as it is, `grep` searches
+it, Git keeps its history, and a program — a language model or an agent among
+them — takes it as input without a parser or an API. That is the general case,
+and it needs no account anywhere; the plugins that publish to a service are for
+when a particular service is the point.
+
 Automatic Ruby exists so that those jobs are assembled instead. It contributes
 exactly three things:
 
@@ -91,8 +102,11 @@ plainly which of its plugins still work. See [`doc/VERSIONS`](doc/VERSIONS).
 
 - **Recipes in YAML.** A job is a file, not a program. No Ruby is written to
   wire a pipeline together.
-- **Forty-four plugins** across seven categories: subscribe, custom feed,
+- **Forty-five plugins** across seven categories: subscribe, custom feed,
   filter, store, provide, notify, publish.
+- **Markdown out of the box.** `PublishMarkdown` writes the result as a plain
+  Markdown document, to a file or to standard output, with no service and no
+  credential behind it. It is the natural end of a new Recipe.
 - **Plugins are found, not registered.** Adding one is dropping a file in a
   directory. No framework file is edited.
 - **Your plugins override the shipped ones.** `~/.automatic/plugins` is searched
@@ -186,15 +200,20 @@ use the plugin; the table is in [`doc/DEPLOYMENT.md`](doc/DEPLOYMENT.md).
 
 ```sh
 automatic scaffold
-automatic -c ~/.automatic/config/example/feed2console.yml
+automatic -c ~/.automatic/config/example/feed2markdown.yml
 ```
 
 `scaffold` creates `~/.automatic` with `config/`, `plugins/`, `db/` and
 `assets/`, and copies the example Recipes into `~/.automatic/config/example`.
 It never overwrites anything already there.
 
-The example Recipe fetches one blog's feed and prints it. To check the framework
-without any network, write this instead:
+That Recipe fetches one blog's feed, skips what it has published before, and
+appends the rest to `~/.automatic/markdown/feeds.md`. Run it twice: the second
+run leaves the file alone, because the store plugin has seen it all. Read the
+file, `grep` it, put it in a repository, or hand it to whatever reads text next.
+`feed2console.yml` beside it is the same pipeline printing to the terminal.
+
+To check the framework without any network, write this instead:
 
 ```yaml
 # ~/.automatic/config/selftest.yml
@@ -204,7 +223,7 @@ plugins:
       feeds:
         - title: hello
           url: https://example.com/
-  - module: PublishConsoleLink
+  - module: PublishMarkdown
 ```
 
 ```sh
@@ -294,21 +313,21 @@ the same fact written twice, and the loader converts between them.
 | `Store` | `store/` | Persist, and drop what was seen before |
 | `Provide` | `provide/` | Emit the payload elsewhere |
 | `Notify` | `notify/` | Send a notification |
-| `Publish` | `publish/` | Send the result out, or print it |
+| `Publish` | `publish/` | Send the result out, print it, or write it as a document |
 
 `~/.automatic/plugins` is searched **before** the installation, so a file named
 like a shipped plugin replaces it.
 
 ### Which plugins still work
 
-Forty-four plugins ship with the gem, written between 2012 and 2015. Several
-talk to services that have since shut down. Every one is classified in
-[`doc/PLUGINS.md`](doc/PLUGINS.md) section 6, with its settings and the reason
-for its status:
+Forty-five plugins ship with the gem, most of them written between 2012 and
+2015. Several talk to services that have since shut down. Every one is
+classified in [`doc/PLUGINS.md`](doc/PLUGINS.md) section 6, with its settings
+and the reason for its status:
 
 | Status | Count | Meaning |
 | --- | --- | --- |
-| **Supported** | 22 | Works on the supported Rubies with current dependencies |
+| **Supported** | 23 | Works on the supported Rubies with current dependencies |
 | **Supported (external)** | 9 | Works, but needs something you provide: a service, a command, a data file |
 | **Needs rework** | 3 | The service exists; this plugin speaks a replaced interface |
 | **Unsupported** | 10 | The service has shut down |
@@ -533,7 +552,7 @@ this repository. No document here defers to another repository.
 | --- | --- |
 | [`doc/REQUIREMENTS.md`](doc/REQUIREMENTS.md) | What the system is for, what it guarantees, where its responsibility ends |
 | [`doc/BASIC_DESIGN.md`](doc/BASIC_DESIGN.md) | How it is composed: the parts, their responsibilities, the flow of a run |
-| [`doc/PLUGINS.md`](doc/PLUGINS.md) | The Recipe format, the plugin contract, and the catalogue of all 44 plugins |
+| [`doc/PLUGINS.md`](doc/PLUGINS.md) | The Recipe format, the plugin contract, and the catalogue of all 45 plugins |
 | [`doc/POLICY.md`](doc/POLICY.md) | How a change is made and judged: style, dependencies, tests, versioning |
 | [`doc/DEPLOYMENT.md`](doc/DEPLOYMENT.md) | Installing, scheduling, operating, and what to do when it fails |
 | [`doc/VERSIONS`](doc/VERSIONS) | The release history, from 2012 |

--- a/config/feed2markdown.yml
+++ b/config/feed2markdown.yml
@@ -1,0 +1,46 @@
+# Collect, filter, de-duplicate, and leave the result as a Markdown document.
+#
+#   automatic -c ~/.automatic/config/example/feed2markdown.yml
+#
+# The document is readable as it stands, searchable with grep, worth keeping in
+# version control, and ready to hand to a program that takes text as input.
+# Nothing here needs an account, a credential or a service.
+#
+# Safe to run from cron: StorePermalink records what has already been written,
+# so a later run appends only what is new and a run that finds nothing new
+# leaves the file untouched. See doc/DEPLOYMENT.md.
+#
+# To send the document to standard output instead, drop the PublishMarkdown
+# config and set the log level to none, so that only the document is written:
+#
+#   automatic -c feed2markdown.yml > today.md
+
+global:
+  log:
+    level: info
+
+plugins:
+  - module: SubscriptionFeed
+    config:
+      feeds:
+        - http://blog.id774.net/post/feed/
+      retry: 3
+      interval: 5
+
+  - module: FilterIgnore
+    config:
+      title:
+        - Sponsored
+
+  - module: FilterSort
+    config:
+      sort: asc
+
+  - module: StorePermalink
+    config:
+      db: feed2markdown.db
+
+  - module: PublishMarkdown
+    config:
+      file: ~/.automatic/markdown/feeds.md
+      mode: append

--- a/doc/BASIC_DESIGN.md
+++ b/doc/BASIC_DESIGN.md
@@ -257,6 +257,43 @@ The categories are a convention with one mechanical consequence — the director
 name is part of the lookup key (section 4.6) — and no other. Nothing enforces
 that a `Filter` does not reach the network.
 
+**`Publish` is the boundary at which the pipeline meets a representation that is
+not the pipeline's.** A publishing plugin reads the value described in section
+4.8, writes it out in whatever form its destination wants — a line on a
+terminal, a request body, a record for a log collector, a document on disk — and
+returns the value it was given, unchanged. The conversion is the plugin's whole
+job and it happens in one direction, at one point:
+
+```text
+RSS-shaped pipeline
+      |
+      v
+Publish<Something>          the plugin: serialize, then emit
+      |
+      v
+the destination's own form  a terminal line, a JSON record, a Markdown document
+```
+
+`PublishMarkdown` is one of these and is architecturally unremarkable: it
+renders each item as a Markdown section and writes the result to standard output
+or to a file. What matters to this document is where it is *not*:
+
+- **Not in the framework.** `Automatic::Pipeline` gains no knowledge of
+  Markdown, `Automatic::FeedMaker` gains no Markdown constructor, and no
+  framework file mentions the format. A reference to it in `lib/` would be the
+  same design error as a reference to any other plugin (section 3).
+- **Not a second pipeline value.** Markdown is produced *from* the pipeline at
+  the moment the pipeline ends; it is never passed along one. The plugin returns
+  its input, so a plugin placed after it receives exactly what it would have
+  received without it, and Invariant 2 of [`POLICY.md`](POLICY.md) is untouched.
+- **Not implicit.** Nothing appends it to a Recipe. `Pipeline.run` runs the
+  entries the Recipe lists, in order, and that is still the whole of its
+  behaviour.
+
+Its specification — what it writes for each field, how HTML in a body is
+reduced, where the output goes — is in [`PLUGINS.md`](PLUGINS.md) section 6.7,
+because it is a plugin's specification and not a property of the design.
+
 Two shared pieces sit inside `plugins/` rather than in `lib/`, because they are
 plugin implementation and the framework does not use them:
 
@@ -331,6 +368,35 @@ Three properties of that flow are the design:
 - Nothing between the steps inspects the value. The framework never looks inside
   a feed.
 
+The last entry decides what the run leaves behind, and changing it changes
+nothing else. The same four steps ending in `PublishMarkdown` produce a document
+instead of terminal output:
+
+```text
+acquire            SubscriptionFeed, SubscriptionLink, CustomFeed*, ...
+   |                 many sources, one shape
+   v
+filter             FilterIgnore, FilterSanitize, FilterSort, ...
+   |
+   v
+store              StorePermalink: what has not been seen before
+   |
+   v
+publish            PublishMarkdown: serialize at the boundary
+   |
+   v
+Markdown           a file, or standard output
+   |
+   +--> read by a person
+   +--> searched with grep, processed with the usual tools
+   +--> committed, diffed, kept
+   +--> handed to a program, a language model or an agent
+```
+
+Everything above the last box is unchanged from the previous diagram, which is
+the point: the acquisition, the filtering and the de-duplication are the same
+plugins over the same value, and the exit is the part the Recipe chooses.
+
 ## 6. Settings
 
 Two kinds, and they do not mix.
@@ -386,9 +452,26 @@ a defect and its backtrace is wanted.
   for requested output — help, version, and the results of the diagnostic
   subcommands.
 - Publishing plugins whose entire purpose is to print (`PublishConsole`,
-  `PublishConsoleLink`) write to an output object held in an instance variable,
-  defaulting to `$stdout`. That is what lets their specs assert on what was
-  printed by substituting a double.
+  `PublishConsoleLink`, `PublishMarkdown` with no `file` setting) write to an
+  output object held in an instance variable, defaulting to `$stdout`. That is
+  what lets their specs assert on what was printed by substituting a double.
+
+The log and a publishing plugin's output therefore share standard output, which
+has never mattered — a `pretty_inspect` dump and a log line interleave without
+either becoming unreadable — and matters for a plugin whose output is a document
+meant to be redirected into a file. The design does not resolve this by giving
+the log a second destination: `Automatic::Log` writing to standard output is
+long-standing behaviour that Recipes and `cron` entries are written around
+(`REQUIREMENTS.md` section 14), and changing it for one plugin's benefit would
+be the framework acquiring a plugin's problem. It is resolved where the choice
+already exists — in the Recipe:
+
+- `global.log.level: none` silences the log for that run, leaving standard
+  output carrying the document alone;
+- or the plugin writes to a file it is given, and the log keeps standard output.
+
+Both are stated in [`PLUGINS.md`](PLUGINS.md) section 6.7 and in
+[`DEPLOYMENT.md`](DEPLOYMENT.md), which is where an operator looks.
 
 ## 9. Testability
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -216,6 +216,88 @@ automatic inspect https://example.com/           # both, in one step
 automatic opmlparser subscriptions.opml          # the feed URLs in an OPML export
 ```
 
+## Publishing to a Markdown document
+
+A Recipe that ends in `PublishMarkdown` leaves what it collected as a Markdown
+file, with no service and no credential involved. The plugin's specification —
+what it writes for each field, and what it does with HTML in a body — is
+[`PLUGINS.md`](PLUGINS.md) section 6.7. What matters when running it
+unattended is below.
+
+```yaml
+  - module: StorePermalink
+    config:
+      db: feeds.db
+
+  - module: PublishMarkdown
+    config:
+      file: ~/notes/feeds.md
+      mode: append
+```
+
+**The output path.** `file` is expanded, so `~` works, and a relative path is
+resolved against the process's working directory — which under `cron` is your
+home directory and is not worth relying on. Use an absolute path or a `~` path.
+A missing parent directory is created; nothing else on the path is touched, and
+the plugin writes to no other file.
+
+**Append or overwrite.** `mode: append`, the default, adds the run's items to
+the end of the file, which is what a Recipe in `cron` wants: with a store plugin
+in front of it, each run contributes only what is new and the file becomes a
+journal. `mode: overwrite` replaces the file, for a Recipe whose output is meant
+to be the current state rather than a history — a digest regenerated every
+morning, say. In either mode a run that produces no items writes nothing at all:
+the file is not created, not appended to and not truncated, so a quiet run
+leaves yesterday's document intact.
+
+**Permissions.** The file is created with your umask, like any other file the
+process writes. The plugin does not adjust it. Where the collected material is
+private, put the document in a directory you have restricted rather than relying
+on the file's own mode:
+
+```sh
+mkdir -p ~/notes && chmod 700 ~/notes
+```
+
+**Keeping the document clean.** With no `file`, the document goes to standard
+output — and so does the log ([`REQUIREMENTS.md`](REQUIREMENTS.md) section 14),
+so a redirect that collects one collects the other. Two ways out, and the Recipe
+chooses:
+
+```yaml
+global:
+  log:
+    level: none         # standard output then carries the document alone
+```
+
+```sh
+automatic -c feeds.yml > today.md
+```
+
+or give the plugin a `file`, which leaves standard output to the log and is what
+a `cron` entry wants, since the log is what you have afterwards when something
+went wrong:
+
+```crontab
+  0 7 * * *  /usr/local/bin/automatic -c $HOME/.automatic/config/feeds.yml >> $HOME/.automatic/log/feeds.log 2>&1
+```
+
+Redirecting the document itself from `cron` works as well, and then the log
+needs somewhere else to go:
+
+```crontab
+  0 7 * * *  /usr/local/bin/automatic -c $HOME/.automatic/config/feeds.yml >> $HOME/notes/feeds.md 2>>$HOME/.automatic/log/feeds.log
+```
+
+That entry is only clean if the Recipe sets `log.level: none`; otherwise the log
+lines land in the document. Setting the level in the Recipe is the supported
+way to do this, and the framework has no separate switch for it.
+
+**Afterwards.** The file is ordinary text: read it, `grep` it, feed it to
+another program, or keep it in a Git repository and commit after each run. The
+plugin writes nothing that changes between runs of the same pipeline, so a
+commit shows what arrived and nothing else.
+
 ## Credentials
 
 Plugins that reach an authenticated service take their credentials as ordinary

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -432,7 +432,7 @@ message construction — and the rest is left to the integration Recipes under
 | `Store` | Persist, and drop what has been seen before | Send anything outward |
 | `Provide` | Emit `content_encoded` elsewhere | Alter the pipeline |
 | `Notify` | Send a notification, return the pipeline unchanged | Alter the pipeline |
-| `Publish` | Send the result out, or print it; return the pipeline | Alter the pipeline |
+| `Publish` | Send the result out, print it, or write it as a document; return the pipeline | Alter the pipeline |
 
 Nothing enforces this. It is what makes a Recipe readable, and it is what a
 reviewer will ask about.
@@ -896,7 +896,155 @@ Honours a `PROXY` environment variable, on port 8080.
 
 ### 6.7 Publish
 
-Send the result outward, or print it. Normally last in a Recipe.
+Send the result outward, or print it. Normally last in a Recipe. This is where
+the pipeline is written out in a form that is not the pipeline's own, so each of
+these plugins is a serializer as much as a destination.
+
+#### PublishMarkdown — **Supported**
+
+`publish/markdown.rb`. Renders the pipeline as a Markdown document and writes it
+to standard output or to a file. It needs no service, no account and no
+credential, which is what makes it the plugin a Recipe can end with on any
+machine, and the one to reach for when the result is meant to be read later —
+by a person, by `grep`, by whatever is given the file next.
+
+```yaml
+  - module: PublishMarkdown
+    config:
+      file: ~/notes/feeds.md
+      mode: append
+```
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `file` | string | Path of the file to write. `~` is expanded and a missing parent directory is created. Absent: standard output. |
+| `mode` | string | `append`, the default, or `overwrite`. Read only when `file` is set. |
+
+Both are optional: `PublishMarkdown` with no `config` writes the document to
+standard output.
+
+##### What it writes
+
+One section per item, in pipeline order — the feeds in the order they arrive,
+the items in the order their feed carries them. Nothing sorts, groups or
+de-duplicates here; `FilterSort` and the store plugins are where that belongs.
+
+```markdown
+## An item's title
+
+- Link: <https://example.com/a>
+- Date: 2026-08-14 10:00:00 +0900
+- Author: someone@example.com
+
+The body of the item, as text.
+```
+
+- **The title is a level-2 ATX heading**, and that heading is the item boundary:
+  a section starts at `## ` and runs to the next one. An item with no title uses
+  its link as the heading, and an item with neither is headed `(untitled)`.
+  Level 2 rather than level 1, so that a document these sections are collected
+  into can carry a title of its own.
+- **The metadata list** follows the heading: one `- Field: value` bullet per
+  field the item carries, in the fixed order `Link`, `Date`, `Author`,
+  `Comments`, `Source`, `Enclosure`. A field that is `nil` or empty produces no
+  bullet, and an item carrying none produces no list. URLs are written as
+  autolinks — `<https://example.com/a>` — so that a renderer makes them links
+  and `grep` still sees the URL.
+- **The body** is `content_encoded` when the item has one, and `description`
+  otherwise, on the ground that a feed carrying both puts the summary in the
+  second and the article in the first. An item with neither has no body, and its
+  section is the heading and the metadata list.
+- **The date** is formatted `%Y-%m-%d %H:%M:%S %z` from the item's own date, in
+  the zone that date carries. Nothing is converted to local time, because the
+  same input then produces the same output on any machine.
+- **`source` and `enclosure` are elements rather than strings** in a parsed
+  feed. The source's text is used, and the enclosure's URL; where either is
+  already a plain string it is used as it stands.
+- **A section is followed by a blank line.** Appending a document to a document
+  therefore stays valid Markdown, and a file always ends with a newline.
+- **Nothing else is emitted.** No YAML front matter, no run header, no
+  timestamp of the run, no horizontal rules — nothing that is not in the
+  pipeline. The output for a given pipeline is byte-for-byte the same on every
+  run, which is what makes it worth committing and diffing. A format is easy to
+  add later and impossible to take away, so this one starts as ordinary
+  Markdown and no more.
+- **An empty pipeline writes nothing at all**: no file is created, and an
+  existing file is neither appended to nor truncated. A run in which the store
+  plugin found nothing new leaves the document exactly as it was.
+
+##### HTML in a body
+
+`description` and `content_encoded` carry HTML in most real feeds, and a
+document that dumped it unchanged would be HTML in a file named `.md` rather
+than Markdown. What the plugin does instead:
+
+- A body with no markup in it is passed through as it stands.
+- A body containing markup is **reduced to text**: `script` and `style` are
+  dropped with their contents, `<br>` becomes a line break, block elements
+  become paragraph breaks, character entities are decoded, and the tags
+  themselves are discarded.
+- In both cases the whitespace is normalized: line endings become `\n`,
+  trailing whitespace goes, and a run of blank lines collapses to one. Text
+  that came from markup also loses the source document's own indentation, which
+  is layout rather than content and which Markdown would otherwise read as a
+  code block.
+
+This is deliberately **not** an HTML-to-Markdown translation. Rendering
+arbitrary markup back into equivalent Markdown — tables, nested lists, inline
+links, images — is a large job with a large library behind it, and a library
+that size does not become a dependency for one plugin
+([`POLICY.md`](POLICY.md) section 9.1). Reducing markup to text needs nothing
+that is not already installed: `nokogiri` is a runtime dependency, used by the
+framework's own feed adapters. The result is defined by its two ends — the
+text survives, the markup does not — which is what both a reader and a program
+reading the file want from it. A link inside a body becomes its own text; the
+item's own link is in the metadata list, where nothing loses it.
+
+Where a different treatment is wanted, the pipeline already has the means:
+`FilterSanitize` before this plugin decides what markup survives into the
+description, and this plugin then reduces what is left.
+
+The body is otherwise written as it is: Markdown is **not** escaped, so a body
+line beginning with `#` or `-` renders as a heading or a list item. Escaping it
+would make the text worse to read in exchange for a rendering nothing depends
+on.
+
+##### Where the output goes
+
+With `file`, the document is written there, appended by default so that a
+Recipe in `cron` builds up one growing document, and `mode: overwrite` replaces
+the file when what is wanted is the current state rather than a history. The
+plugin writes only that file, and only what its `config` names.
+
+With no `file`, the document goes to standard output, which is what a pipe or a
+shell redirect wants:
+
+```sh
+automatic -c feeds.yml > today.md
+```
+
+Standard output is also where `Automatic::Log` writes
+([`REQUIREMENTS.md`](REQUIREMENTS.md) section 14), so a redirect collects the
+log lines into the document as well. Set the log level for that Recipe, which
+is the setting that already exists for it:
+
+```yaml
+global:
+  log:
+    level: none
+
+plugins:
+  # ...
+  - module: PublishMarkdown
+```
+
+`file` avoids the question entirely: the document goes to the file and the log
+keeps standard output. Which to use is an operational choice and
+[`DEPLOYMENT.md`](DEPLOYMENT.md) says more about it.
+
+The plugin logs one line per run at `info`, naming the destination and the
+number of items written; it does not log a line per item, because that log is
+what would be interleaved with the document.
 
 #### PublishConsole — **Supported**
 
@@ -1032,12 +1180,12 @@ passed through even when the API existed.
 
 | Status | Count | Plugins |
 | --- | --- | --- |
-| Supported | 22 | `SubscriptionFeed`, `SubscriptionLink`, `SubscriptionXml`, `SubscriptionText`, `FilterIgnore`, `FilterAccept`, `FilterSort`, `FilterOne`, `FilterRand`, `FilterClear`, `FilterImage`, `FilterImageSource`, `FilterAbsoluteURI`, `FilterSanitize`, `FilterTumblrResize`, `FilterDescriptionLink`, `FilterGithubFeed`, `StorePermalink`, `StoreFullText`, `StoreFile`, `PublishConsole`, `PublishConsoleLink` |
+| Supported | 23 | `SubscriptionFeed`, `SubscriptionLink`, `SubscriptionXml`, `SubscriptionText`, `FilterIgnore`, `FilterAccept`, `FilterSort`, `FilterOne`, `FilterRand`, `FilterClear`, `FilterImage`, `FilterImageSource`, `FilterAbsoluteURI`, `FilterSanitize`, `FilterTumblrResize`, `FilterDescriptionLink`, `FilterGithubFeed`, `StorePermalink`, `StoreFullText`, `StoreFile`, `PublishMarkdown`, `PublishConsole`, `PublishConsoleLink` |
 | Supported (external) | 9 | `SubscriptionTumblr`, `CustomFeedSVNLog`, `FilterFullFeed`, `ProvideFluentd`, `NotifyIkachan`, `PublishEject`, `PublishMemcached`, `PublishFluentd`, `PublishInstapaper` |
 | Needs rework | 3 | `FilterGoogleNews`, `PublishAmazonS3`, `PublishHatenaBookmark` |
 | Unsupported | 10 | `SubscriptionTwitter`, `SubscriptionTwitterSearch`, `SubscriptionPocket`, `SubscriptionWeather`, `SubscriptionGGuide`, `SubscriptionChanToru`, `PublishTwitter`, `PublishPocket`, `PublishHipchat`, `PublishGoogleCalendar` |
 
-Forty-four plugins, of which the S3 path of `StoreFile` is counted with the
+Forty-five plugins, of which the S3 path of `StoreFile` is counted with the
 Supported row and noted separately in section 6.4.
 
 A Recipe using only the first two rows is a Recipe that can be expected to run.

--- a/doc/POLICY.md
+++ b/doc/POLICY.md
@@ -348,6 +348,13 @@ repository level only; see section 10.
 
 - A new plugin follows [`PLUGINS.md`](PLUGINS.md) section 3, which is the
   contract, and section 3.10, which says which category it belongs in.
+- **Converting the pipeline into some other representation is a `Publish`
+  plugin's work, and the result stays inside the plugin.** It is serialized at
+  the boundary, written to the destination, and never passed along the pipeline
+  or made known to the framework, which keeps Invariant 2 and section 1.5
+  intact. Producing a portable document — one a person can read, ordinary tools
+  can process and another program can be given, with no service behind it — is
+  a destination like any other and belongs in that category.
 - A new plugin is added to the catalogue in `PLUGINS.md` section 6 in the same
   change, with its settings table and its status.
 - A new plugin comes with a spec that reaches no network.

--- a/doc/REQUIREMENTS.md
+++ b/doc/REQUIREMENTS.md
@@ -146,6 +146,13 @@ makes them compose. Three consequences are requirements:
 The value has no schema beyond that, no validation and no version. A plugin that
 needs a field the previous plugin never set gets `nil`.
 
+This is an **internal** representation, and it is not a statement about what a
+run produces. A plugin that writes the pipeline out in some other form — a
+Markdown document, a row in a database, a request body — serializes it at the
+moment it leaves the pipeline, and the value the next plugin receives is
+unchanged. An output format is therefore never a second pipeline
+representation, and shall not become one; see section 10.2.
+
 ## 9. Input
 
 The framework itself reads:
@@ -163,6 +170,8 @@ The framework passes no ambient input to plugins. A plugin's entire input is the
 
 ## 10. Output
 
+### 10.1 What the framework writes
+
 The framework itself writes:
 
 - **a log**, to standard output (section 14),
@@ -174,6 +183,58 @@ does not know what any of it is and does not verify it.
 
 The final pipeline value is discarded. A Recipe whose last plugin only
 transforms the pipeline has done nothing observable, and that is not an error.
+
+### 10.2 What a run publishes
+
+Where the collected information ends up is decided by the Recipe, and the
+plugins that decide it are the `Publish` category. Two kinds of destination have
+always existed side by side: a remote service, reached with a credential over
+the network, and something local — the terminal, a file, a database. Neither is
+the system's purpose. Automatic Ruby is not a means of feeding one particular
+reader, one particular service or one particular protocol, and a requirement
+written as though it were would be wrong about what the system is for.
+
+Leaving the collected information behind as a **document that outlives the run**
+is as much a use of the system as sending it somewhere. That document is read by
+a person, kept in version control, searched with ordinary Unix tools, and given
+to a program — including a large language model or an agent — as input to
+summarize, classify or reorganize. These are the same document and the same
+requirement, not two.
+
+**Markdown is the standard publication format** for that purpose, in the sense
+that it is what a Recipe publishes when it has no reason to publish to a
+particular service. Its properties are the reason, and they are technical ones:
+
+- a person reads it as it is, with no tool and no rendering step;
+- it diffs and merges, so a growing document belongs in Git;
+- `grep`, `sed` and the rest operate on it without a parser;
+- a program consumes it as text, which is the form a language model or an agent
+  takes its input in;
+- it needs no service, no account, no credential and no network;
+- it is plain text, so it stays readable for as long as the filesystem does.
+
+The requirements that follow:
+
+- **A publication format shall be available that needs nothing outside the
+  machine.** A Recipe that collects, filters and de-duplicates shall be able to
+  finish by writing what it has, without an account anywhere.
+- **Markdown output is an ordinary Publish plugin**, subject to the plugin
+  contract of section 7.2 and to nothing else. It is not a framework feature,
+  the framework gains no knowledge of Markdown, and section 23 applies to it as
+  to anything else.
+- **Nothing is published implicitly.** A Recipe publishes what it names and
+  nothing more. The framework shall not append a publishing step to a Recipe
+  that does not ask for one, and a Recipe written before Markdown output existed
+  shall behave exactly as it did.
+- **The output format is not the pipeline value.** Serializing to Markdown
+  happens at the boundary, in the publishing plugin, and leaves section 8's
+  value untouched. No second representation is introduced, and the plugins
+  before and after are unaffected.
+- **RSS and Atom remain input formats.** `SubscriptionFeed` and the rest are
+  unaffected by any of this: a feed is still one of the ordinary ways to acquire
+  something, and none of it is deprecated. That the pipeline value has the shape
+  of a feed is an internal matter (section 8); it neither obliges a run to
+  publish a feed nor makes feeds less useful to read.
 
 ## 11. The command line
 

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -51,6 +51,14 @@ v26.08 (Release Date: TBD)
 - Rewrite README.md around the current repository, and move the release history from doc/ChangeLog into this file without changing an entry or a date.
 - Remove doc/README and doc/PLUGINS, whose content is now in README.md, doc/BASIC_DESIGN.md and doc/PLUGINS.md.
 - Keep doc/README.ja and doc/PLUGINS.ja as historical Japanese documentation, marked as describing the software as it was.
+- Add PublishMarkdown, which renders the pipeline as a Markdown document to a file or to standard output, needing no service and no credential; forty-five plugins now ship, twenty-three of them Supported.
+- Require in doc/REQUIREMENTS.md that a run can publish a portable document, name Markdown as the standard publication format for that, and state that an output format is never a second pipeline representation and that RSS and Atom stay input formats.
+- Place PublishMarkdown in doc/BASIC_DESIGN.md as a serializer at the Publish boundary, keeping Markdown out of the framework, out of the pipeline value and out of any implicit step, and record how the log and a document share standard output.
+- Specify PublishMarkdown in doc/PLUGINS.md: a level-2 heading per item, a metadata list of the fields it carries, content_encoded before description, HTML reduced to text with nokogiri rather than translated, deterministic output, and the file and mode settings.
+- Add config/feed2markdown.yml, collecting a feed, filtering it, de-duplicating with StorePermalink and appending what is new to a Markdown file.
+- Document Markdown output for unattended use in doc/DEPLOYMENT.md: the output path, append and overwrite semantics, file permissions, and keeping the log out of the document with global.log.level.
+- State in doc/POLICY.md that converting the pipeline into another representation is a Publish plugin's work and that the result stays inside the plugin.
+- Rewrite the README's opening example and quick start around Markdown output, so that collect, filter, de-duplicate and write a document reads as an ordinary use of the framework.
 
 v14.12.2 (2015-01-04)
 ---------------------

--- a/plugins/publish/markdown.rb
+++ b/plugins/publish/markdown.rb
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+# Name::      Automatic::Plugin::Publish::Markdown
+# Description:: Render the pipeline as a Markdown document, to a file or to standard output.
+# Author::    774 <http://id774.net>
+# Created::   Aug 14, 2026
+# Updated::   Aug 14, 2026
+# Copyright:: Copyright (c) 2012-2026 Automatic Ruby Developers.
+# License::   Licensed under the GNU GENERAL PUBLIC LICENSE, Version 3.0.
+
+module Automatic::Plugin
+  class PublishMarkdown
+    require 'fileutils'
+    require 'nokogiri'
+
+    # Written under an item's heading, in this order. A field the item does not
+    # carry produces no bullet at all, so an item is not padded out with empty
+    # ones. See doc/PLUGINS.md section 6.7.
+    METADATA_FIELDS = [
+      ['Link',      :link],
+      ['Date',      :date],
+      ['Author',    :author],
+      ['Comments',  :comments],
+      ['Source',    :source],
+      ['Enclosure', :enclosure]
+    ].freeze
+
+    # Elements that end a line of text. Everything else is unwrapped: the body
+    # is reduced to text rather than translated into Markdown, because doing
+    # the latter properly needs a library this framework declines to depend on.
+    BLOCK_ELEMENTS = %w[
+      address article aside blockquote dd div dl dt figcaption figure footer
+      form h1 h2 h3 h4 h5 h6 header hr li main nav ol p pre section table
+      tbody td th thead tr ul
+    ].freeze
+
+    # A body counts as HTML when it carries a tag or a character entity. One
+    # that carries neither is written as it stands, so that a "<" in a
+    # plain-text description is not parsed away.
+    MARKUP = %r{<[a-zA-Z/!]|&[a-zA-Z#][0-9a-zA-Z]*;}
+
+    # The item's own date, in the zone the item carries. Nothing is converted
+    # to local time: the same pipeline then produces the same document
+    # wherever it runs.
+    DATE_FORMAT = '%Y-%m-%d %H:%M:%S %z'
+
+    UNTITLED = '(untitled)'
+
+    def initialize(config, pipeline=[])
+      @config   = config || {}
+      @pipeline = pipeline
+      @output   = $stdout
+      @file     = @config['file'].nil? ? nil : File.expand_path(@config['file'].to_s)
+      @mode     = @config['mode'] == 'overwrite' ? 'w' : 'a'
+    end
+
+    def run
+      sections = render
+      write(sections) unless sections.empty?
+      @pipeline
+    end
+
+    private
+
+    def render
+      sections = []
+      @pipeline.each {|feeds|
+        next if feeds.nil?
+
+        feeds.items.each {|feed|
+          sections << section(feed)
+        }
+      }
+      sections
+    end
+
+    # Heading, then the metadata list, then the body, each separated by a blank
+    # line and the whole followed by one. Appending a document to a document is
+    # then still a Markdown document.
+    def section(feed)
+      parts = ["## #{heading(feed)}\n"]
+      metadata = metadata_list(feed)
+      parts << metadata unless metadata.empty?
+      body = body_text(feed)
+      parts << body unless body.empty?
+      parts.join("\n") + "\n"
+    end
+
+    def heading(feed)
+      title = one_line(value(feed, :title))
+      return title unless title.empty?
+
+      link = one_line(value(feed, :link))
+      link.empty? ? UNTITLED : link
+    end
+
+    def metadata_list(feed)
+      METADATA_FIELDS.map {|label, name|
+        text = name == :date ? date(feed) : one_line(value(feed, name))
+        next if text.empty?
+
+        "- #{label}: #{url?(text) ? "<#{text}>" : text}\n"
+      }.compact.join
+    end
+
+    # content_encoded when the item has one and description otherwise: a feed
+    # carrying both puts the summary in the second and the article in the first.
+    def body_text(feed)
+      text = value(feed, :content_encoded)
+      text = value(feed, :description) if text.empty?
+      MARKUP.match?(text) ? normalize(html_to_text(text), true) : normalize(text, false)
+    end
+
+    def date(feed)
+      field = feed.respond_to?(:date) ? feed.date : nil
+      return '' if field.nil?
+
+      field.respond_to?(:strftime) ? field.strftime(DATE_FORMAT) : one_line(field.to_s)
+    end
+
+    # Any field may be absent, and a parsed feed answers with an element rather
+    # than a string where the format has one: a source carries its text in
+    # #content, an enclosure its URL in #url.
+    def value(feed, name)
+      return '' unless feed.respond_to?(name)
+
+      field = feed.send(name)
+      return '' if field.nil?
+
+      if field.respond_to?(:content)
+        field.content.to_s.strip
+      elsif field.respond_to?(:url)
+        field.url.to_s.strip
+      else
+        field.to_s.strip
+      end
+    end
+
+    def one_line(text)
+      text.gsub(/\s+/, ' ').strip
+    end
+
+    def url?(text)
+      text.match?(%r{\A[a-zA-Z][a-zA-Z0-9+.-]*://\S+\z})
+    end
+
+    # Reduce markup to text: script and style go with their contents, a break
+    # ends a line, a block element ends a paragraph, entities are decoded by
+    # the parser, and the tags themselves are dropped.
+    def html_to_text(html)
+      fragment = Nokogiri::HTML.fragment(html)
+      fragment.css('script, style').each {|node| node.remove }
+      fragment.css('br').each {|node| node.replace(text_node(node, "\n")) }
+      fragment.css(BLOCK_ELEMENTS.join(', ')).each {|node|
+        node.add_previous_sibling(text_node(node, "\n"))
+        node.add_next_sibling(text_node(node, "\n\n"))
+      }
+      fragment.text
+    end
+
+    def text_node(node, text)
+      Nokogiri::XML::Text.new(text, node.document)
+    end
+
+    # Line endings become "\n", trailing whitespace goes, and a run of blank
+    # lines collapses to one. Text that came from markup also loses the
+    # source's own indentation, which is layout rather than content and which
+    # Markdown would otherwise read as a code block.
+    def normalize(text, from_markup)
+      lines = text.gsub(/\r\n?/, "\n").split("\n", -1).map {|line|
+        from_markup ? line.gsub(/[[:blank:]]+/, ' ').strip : line.rstrip
+      }
+      normalized = lines.each_with_object([]) {|line, kept|
+        next if line.empty? && (kept.empty? || kept.last.empty?)
+
+        kept << line
+      }
+      normalized.pop while !normalized.empty? && normalized.last.empty?
+      normalized.empty? ? '' : normalized.join("\n") + "\n"
+    end
+
+    # One line per run rather than one per item: this log shares standard
+    # output with the document, and the Recipe decides which of them is wanted
+    # there. See doc/PLUGINS.md section 6.7.
+    def write(sections)
+      document = sections.join
+      counted = sections.size == 1 ? '1 item' : "#{sections.size} items"
+      if @file.nil?
+        @output.print(document)
+        Automatic::Log.puts('info', "Publish Markdown: #{counted} to standard output")
+      else
+        FileUtils.mkdir_p(File.dirname(@file))
+        File.open(@file, @mode, encoding: 'UTF-8') {|out| out.print(document) }
+        Automatic::Log.puts('info', "Publish Markdown: #{counted} to #{@file}")
+      end
+    end
+  end
+end

--- a/spec/plugins/publish/markdown_spec.rb
+++ b/spec/plugins/publish/markdown_spec.rb
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+# Name::      Automatic::Plugin::Publish::Markdown
+# Author::    774 <http://id774.net>
+# Created::   Aug 14, 2026
+# Updated::   Aug 14, 2026
+# Copyright:: Copyright (c) 2012-2026 Automatic Ruby Developers.
+# License::   Licensed under the GNU GENERAL PUBLIC LICENSE, Version 3.0.
+#
+# Reaches no network and needs no credential. The file examples write into a
+# temporary directory and never touch a real ~/.automatic.
+
+require File.expand_path(File.dirname(__FILE__) + '../../../spec_helper')
+
+require 'stringio'
+require 'tmpdir'
+require 'publish/markdown'
+
+describe Automatic::Plugin::PublishMarkdown do
+  # Publishes to the substituted output object, as PublishConsole does, and
+  # returns what was written.
+  def publish(config, pipeline)
+    output = StringIO.new
+    plugin = Automatic::Plugin::PublishMarkdown.new(config, pipeline)
+    plugin.instance_variable_set(:@output, output)
+    @returned = plugin.run
+    output.string
+  end
+
+  describe 'the document' do
+    before do
+      @pipeline = AutomaticSpec.generate_pipeline {
+        feed {
+          item 'https://example.com/a', 'A title', 'A description',
+               'Thu, 14 Aug 2026 10:00:00 +0900', 'someone@example.com'
+        }
+      }
+    end
+
+    it 'writes the title as a level-2 heading' do
+      publish({}, @pipeline).should include("## A title\n")
+    end
+
+    it 'writes the link as an autolink, so a URL survives grep and a renderer' do
+      publish({}, @pipeline).should include("- Link: <https://example.com/a>\n")
+    end
+
+    it 'keeps the date and the author' do
+      document = publish({}, @pipeline)
+      document.should include("- Date: 2026-08-14 10:00:00 +0900\n")
+      document.should include("- Author: someone@example.com\n")
+    end
+
+    it 'writes the description as the body' do
+      publish({}, @pipeline).should include("\nA description\n")
+    end
+
+    it 'writes nothing for a field the item does not carry' do
+      publish({}, @pipeline).should_not include('Comments')
+    end
+
+    it 'ends the document with a blank line, so appending stays valid Markdown' do
+      publish({}, @pipeline).should end_with("\n\n")
+    end
+
+    it 'returns the pipeline it was given' do
+      publish({}, @pipeline)
+      @returned.should equal(@pipeline)
+    end
+
+    it 'is deterministic' do
+      publish({}, @pipeline).should == publish({}, @pipeline)
+    end
+
+    it 'needs no settings' do
+      publish(nil, @pipeline).should include('## A title')
+    end
+  end
+
+  describe 'an item with only a link' do
+    before do
+      @pipeline = AutomaticSpec.generate_pipeline {
+        feed { item 'https://example.com/a' }
+      }
+    end
+
+    it 'heads the section with the link and writes no body' do
+      publish({}, @pipeline).should ==
+        "## https://example.com/a\n\n- Link: <https://example.com/a>\n\n"
+    end
+  end
+
+  describe 'HTML in a body' do
+    before do
+      @pipeline = AutomaticSpec.generate_pipeline {
+        feed {
+          item 'https://example.com/a', 'A title',
+               "<div>\n  <p>First &amp; second.</p>\n" \
+               "  <script>alert(1)</script>\n  <p>Third<br>fourth</p>\n</div>"
+        }
+      }
+    end
+
+    it 'reduces the markup to text' do
+      body = publish({}, @pipeline)
+      body.should include("First & second.\n")
+      body.should_not include('<p>')
+    end
+
+    it 'drops a script with its contents' do
+      publish({}, @pipeline).should_not include('alert(1)')
+    end
+
+    it 'keeps a break as a line break and a block element as a paragraph break' do
+      publish({}, @pipeline).should include("Third\nfourth\n")
+      publish({}, @pipeline).should include("First & second.\n\nThird")
+    end
+  end
+
+  describe 'content_encoded' do
+    before do
+      @pipeline = AutomaticSpec.generate_pipeline {
+        feed { item 'https://example.com/a', 'A title', 'The summary' }
+      }
+      @pipeline[0].items[0].content_encoded = '<p>The article body</p>'
+    end
+
+    it 'is preferred over the description' do
+      document = publish({}, @pipeline)
+      document.should include('The article body')
+      document.should_not include('The summary')
+    end
+  end
+
+  describe 'several items' do
+    before do
+      @pipeline = AutomaticSpec.generate_pipeline {
+        feed {
+          item 'https://example.com/a', 'First'
+          item 'https://example.com/b', 'Second'
+        }
+        feed {
+          item 'https://example.com/c', 'Third'
+        }
+      }
+    end
+
+    it 'writes them in pipeline order' do
+      publish({}, @pipeline).scan(/^## (.+)$/).flatten.should == %w[First Second Third]
+    end
+
+    it 'separates the sections with a blank line' do
+      publish({}, @pipeline).should include("- Link: <https://example.com/a>\n\n## Second\n")
+    end
+
+    it 'skips a feed that is nil' do
+      publish({}, @pipeline + [nil]).scan(/^## /).size.should == 3
+    end
+  end
+
+  describe 'Unicode' do
+    before do
+      @pipeline = AutomaticSpec.generate_pipeline {
+        feed { item 'https://example.com/a', '日本語のタイトル', '<p>本文に &amp; を含む</p>' }
+      }
+    end
+
+    it 'passes text through unchanged' do
+      document = publish({}, @pipeline)
+      document.should include('## 日本語のタイトル')
+      document.should include('本文に & を含む')
+      document.encoding.should == Encoding::UTF_8
+    end
+  end
+
+  describe 'an empty pipeline' do
+    it 'writes nothing' do
+      publish({}, []).should == ''
+    end
+
+    it 'still returns the pipeline' do
+      publish({}, [])
+      @returned.should == []
+    end
+  end
+
+  describe 'a file destination' do
+    before do
+      @pipeline = AutomaticSpec.generate_pipeline {
+        feed { item 'https://example.com/a', '日本語のタイトル' }
+      }
+    end
+
+    around do |example|
+      Dir.mktmpdir {|dir|
+        @dir = dir
+        example.run
+      }
+    end
+
+    it 'writes the document there, creating a missing parent directory' do
+      path = File.join(@dir, 'nested', 'feeds.md')
+      Automatic::Plugin::PublishMarkdown.new({ 'file' => path }, @pipeline).run
+      File.read(path, encoding: 'UTF-8').should == "## 日本語のタイトル\n\n- Link: <https://example.com/a>\n\n"
+    end
+
+    it 'appends by default' do
+      path = File.join(@dir, 'feeds.md')
+      2.times { Automatic::Plugin::PublishMarkdown.new({ 'file' => path }, @pipeline).run }
+      File.read(path, encoding: 'UTF-8').scan(/^## /).size.should == 2
+    end
+
+    it 'replaces the file when told to overwrite' do
+      path = File.join(@dir, 'feeds.md')
+      Automatic::Plugin::PublishMarkdown.new({ 'file' => path }, @pipeline).run
+      Automatic::Plugin::PublishMarkdown.new(
+        { 'file' => path, 'mode' => 'overwrite' }, @pipeline).run
+      File.read(path, encoding: 'UTF-8').scan(/^## /).size.should == 1
+    end
+
+    it 'creates no file for an empty pipeline' do
+      path = File.join(@dir, 'feeds.md')
+      Automatic::Plugin::PublishMarkdown.new({ 'file' => path }, []).run
+      File.exist?(path).should == false
+    end
+
+    it 'returns the pipeline it was given' do
+      path = File.join(@dir, 'feeds.md')
+      plugin = Automatic::Plugin::PublishMarkdown.new({ 'file' => path }, @pipeline)
+      plugin.run.should equal(@pipeline)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Introduces `PublishMarkdown`, a new publishing plugin that serializes the feed pipeline as a Markdown document, writing to either a file or standard output. This enables Recipes to produce human-readable, version-control-friendly output without requiring external services or credentials.

## Key Changes

- **New plugin: `PublishMarkdown`** (`plugins/publish/markdown.rb`)
  - Renders each feed item as a Markdown section with level-2 ATX heading
  - Extracts metadata fields (Link, Date, Author, Comments, Source, Enclosure) as bullet points
  - Converts HTML in descriptions/content_encoded to plain text using Nokogiri
  - Supports writing to file (with append/overwrite modes) or standard output
  - Creates missing parent directories automatically
  - Handles Unicode content correctly
  - Produces deterministic, byte-for-byte identical output across runs

- **Comprehensive test suite** (`spec/plugins/publish/markdown_spec.rb`)
  - 232 lines of specs covering document structure, HTML handling, file I/O, Unicode support
  - Tests metadata extraction, body text normalization, empty pipelines
  - Validates append/overwrite modes and file creation behavior

- **Documentation updates**
  - Extended `doc/PLUGINS.md` section 6.7 with detailed `PublishMarkdown` specification
  - Added `doc/BASIC_DESIGN.md` section explaining the Publish boundary and pipeline serialization
  - Added `doc/DEPLOYMENT.md` section on publishing to Markdown with operational guidance
  - Updated `doc/REQUIREMENTS.md` sections 10.1-10.2 on output and publication formats
  - Updated `doc/POLICY.md` to clarify that format conversion is a Publish plugin responsibility

- **Example configuration** (`config/feed2markdown.yml`)
  - New scaffold example demonstrating a complete feed-to-Markdown workflow
  - Shows integration with SubscriptionFeed, FilterIgnore, FilterSort, and StorePermalink

- **README updates**
  - Updated example to use `PublishMarkdown` instead of `PublishConsole`
  - Added explanation of Markdown as the standard publication format
  - Updated plugin count from 44 to 45

## Implementation Details

- **HTML-to-text conversion**: Reduces markup to plain text rather than translating to Markdown, avoiding a large library dependency. Scripts are removed, block elements become paragraph breaks, `<br>` becomes line breaks, and entities are decoded.

- **Whitespace normalization**: Handles line ending conversion, trailing whitespace removal, and blank line collapsing. Text from markup also has indentation stripped to prevent Markdown code block interpretation.

- **Metadata handling**: Supports both string and element-based fields (source.content, enclosure.url) from parsed feeds. URLs are wrapped as autolinks (`<url>`) for both rendering and grep compatibility.

- **Deterministic output**: Date formatting uses the item's own timezone without conversion, ensuring identical output across machines. Empty pipelines produce no file output.

- **File handling**: Appends by default (suitable for cron jobs building a journal), with optional overwrite mode. Empty runs don't create or modify files.

https://claude.ai/code/session_016JMWCNj1qYTpsxJA9t72uA