### PR TITLE
Exclude generated .gem archives from packaged gem and ignore them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vendor/gems/
 
 # Build output
 pkg/
+*.gem
 
 # Test and coverage output
 coverage/

--- a/automatic.gemspec
+++ b/automatic.gemspec
@@ -74,7 +74,8 @@ Gem::Specification.new do |spec|
   # installed gem impose its own bundle on the program requiring it.
   excluded = %w[.gitignore .github Gemfile Rakefile script spec test vendor]
   spec.files = tracked.reject { |path|
-    excluded.any? { |prefix| path == prefix || path.start_with?("#{prefix}/") }
+    path.end_with?('.gem') ||
+      excluded.any? { |prefix| path == prefix || path.start_with?("#{prefix}/") }
   }.select { |path| File.file?(File.join(__dir__, path)) }
 
   spec.bindir             = 'bin'

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -62,6 +62,7 @@ v26.08 (Release Date: TBD)
 - Document Markdown output for unattended use in doc/DEPLOYMENT.md: the output path, append and overwrite semantics, file permissions, and keeping the log out of the document with global.log.level.
 - State in doc/POLICY.md that converting the pipeline into another representation is a Publish plugin's work and that the result stays inside the plugin.
 - Rewrite the README's opening example and quick start around Markdown output, so that collect, filter, de-duplicate and write a document reads as an ordinary use of the framework.
+- Exclude generated gem archives from the package file list, so CLI and test commands remain usable after a local gem build.
 
 v14.12.2 (2015-01-04)
 ---------------------


### PR DESCRIPTION
### Motivation

- Prevent generated gem archives from being accidentally included in the gem package and ensure local builds do not interfere with CLI and test commands.

### Description

- Add `*.gem` to `.gitignore` to avoid committing built gem archives.
- Update `automatic.gemspec` so `spec.files` rejects paths that `end_with?('.gem')`, preventing generated `.gem` files from being shipped in the built gem.
- Document the change in `doc/VERSIONS` explaining that generated gem archives are excluded from the package file list.

### Testing

- No automated tests were run as part of this change; CI configured for the repository will continue to run `bundle install`, `gem build` and the test suite when the PR is exercised.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f2cf5dcc88322bba1e2885296e48b)