### PR TITLE
Restore historical third-party author attribution in source headers

### DIFF
--- a/doc/POLICY.md
+++ b/doc/POLICY.md
@@ -299,8 +299,12 @@ Every Ruby file carries a header comment. The common fields use this form:
 ```
 
 - `Name` is the fully qualified name of what the file defines.
-- The common `Author`, `Source Code`, `License` and `Contact` fields have the
-  same format in every file.
+- `Author` records the author or authors established by the file and its Git
+  history. The former name `774` is normalized to `id774`; third-party authors
+  are never removed or replaced, and multiple authors retain their recorded
+  order. Names and URLs are not inferred when the history does not provide them.
+- The common `Source Code`, `License` and `Contact` fields have the same format
+  in every file.
 - `Created` is never changed.
 - `Updated` is set to the date of a change that affects behaviour. A
   documentation-only or formatting-only change does not touch it.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -3,6 +3,7 @@ automaticruby Repository Version History
 
 v26.08 (Release Date: TBD)
 --------------------------
+- Restore original third-party author attribution in source headers after the header standardization.
 - Change the license from GPLv3-only to a GPLv3 or LGPLv3 dual license, selectable by the user.
 - Add the official LGPLv3 license text and include both license texts and the license explanation in the gem.
 - Align source headers and RubyGems metadata with the dual-license policy.

--- a/lib/automatic/recipe.rb
+++ b/lib/automatic/recipe.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Recipe
-# Author: id774 (More info: http://id774.net)
+# Author: ainame
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/custom_feed/svn_log.rb
+++ b/plugins/custom_feed/svn_log.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::CustomFeed::SVNLog
-# Author: id774 (More info: http://id774.net)
+# Author: kzgs
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/filter/accept.rb
+++ b/plugins/filter/accept.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::Accept
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/filter/full_feed.rb
+++ b/plugins/filter/full_feed.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::FullFeed
-# Author: id774 (More info: http://id774.net)
+# Author: progd (More info: http://d.hatena.ne.jp/progd/20120429/automatic_ruby_filter_full_feed)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/filter/github_feed.rb
+++ b/plugins/filter/github_feed.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::GithubFeed
-# Author: id774 (More info: http://id774.net)
+# Author: Kohei Hasegawa (More info: http://github.com/banyan)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/filter/one.rb
+++ b/plugins/filter/one.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::One
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/filter/rand.rb
+++ b/plugins/filter/rand.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::Rand
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/publish/console_link.rb
+++ b/plugins/publish/console_link.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::ConsoleLink
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/publish/eject.rb
+++ b/plugins/publish/eject.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Eject
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/publish/hipchat.rb
+++ b/plugins/publish/hipchat.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Hipchat
-# Author: id774 (More info: http://id774.net)
+# Author: Kohei Hasegawa (More info: http://github.com/banyan)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/publish/instapaper.rb
+++ b/plugins/publish/instapaper.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Instapaper
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/publish/pocket.rb
+++ b/plugins/publish/pocket.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Pocket
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/publish/twitter.rb
+++ b/plugins/publish/twitter.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Twitter
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/store/database.rb
+++ b/plugins/store/database.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Store::Database
-# Author: id774 (More info: http://id774.net)
+# Author: kzgs
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/subscription/chan_toru.rb
+++ b/plugins/subscription/chan_toru.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::ChanToru
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/subscription/g_guide.rb
+++ b/plugins/subscription/g_guide.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::GGuide
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/subscription/pocket.rb
+++ b/plugins/subscription/pocket.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::Pocket
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/subscription/text.rb
+++ b/plugins/subscription/text.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::Text
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/subscription/twitter_search.rb
+++ b/plugins/subscription/twitter_search.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::TwitterSearch
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/plugins/subscription/weather.rb
+++ b/plugins/subscription/weather.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::Weather
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/lib/automatic/log_spec.rb
+++ b/spec/lib/automatic/log_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Auaotmatic::Log
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/lib/automatic/pipeline_spec.rb
+++ b/spec/lib/automatic/pipeline_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Pipeline
-# Author: id774 (More info: http://id774.net)
+# Author: ainame
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/lib/automatic_spec.rb
+++ b/spec/lib/automatic_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Ruby
-# Author: id774 (More info: http://id774.net)
+# Author: kzgs
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/custom_feed/svn_log_spec.rb
+++ b/spec/plugins/custom_feed/svn_log_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::CustomFeed::SVNFLog
-# Author: id774 (More info: http://id774.net)
+# Author: kzgs
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/filter/accept_spec.rb
+++ b/spec/plugins/filter/accept_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::Accept
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/filter/github_feed_spec.rb
+++ b/spec/plugins/filter/github_feed_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::GithubFeed
-# Author: id774 (More info: http://id774.net)
+# Author: Kohei Hasegawa (More info: http://github.com/banyan)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/filter/image_source_spec.rb
+++ b/spec/plugins/filter/image_source_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::ImageSource
-# Author: id774 (More info: http://id774.net)
+# Author: kzgs
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/filter/one_spec.rb
+++ b/spec/plugins/filter/one_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::One
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/filter/rand_spec.rb
+++ b/spec/plugins/filter/rand_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Filter::Rand
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/publish/eject_spec.rb
+++ b/spec/plugins/publish/eject_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Eject
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/publish/google_calendar_spec.rb
+++ b/spec/plugins/publish/google_calendar_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::CustomFeed::SVNFLog
-# Author: id774 (More info: http://id774.net)
+# Author: kzgs
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/publish/hipchat_spec.rb
+++ b/spec/plugins/publish/hipchat_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Hipchat
-# Author: id774 (More info: http://id774.net)
+# Author: Kohei Hasegawa (More info: http://github.com/banyan)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/publish/instapaper_spec.rb
+++ b/spec/plugins/publish/instapaper_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Instapaper
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/publish/pocket_spec.rb
+++ b/spec/plugins/publish/pocket_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Pocket
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/publish/twitter_spec.rb
+++ b/spec/plugins/publish/twitter_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Publish::Twitter
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/store/file_spec.rb
+++ b/spec/plugins/store/file_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Store::File
-# Author: id774 (More info: http://id774.net)
+# Author: kzgs
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/subscription/chan_toru_spec.rb
+++ b/spec/plugins/subscription/chan_toru_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::ChanToru
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/subscription/g_guide_spec.rb
+++ b/spec/plugins/subscription/g_guide_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::GGuide
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/subscription/pocket_spec.rb
+++ b/spec/plugins/subscription/pocket_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::Pocket
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/subscription/text_spec.rb
+++ b/spec/plugins/subscription/text_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::Text
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/subscription/twitter_search_spec.rb
+++ b/spec/plugins/subscription/twitter_search_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::TwitterSearch
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com

--- a/spec/plugins/subscription/weather_spec.rb
+++ b/spec/plugins/subscription/weather_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::      Automatic::Plugin::Subscription::Weather
-# Author: id774 (More info: http://id774.net)
+# Author: soramugi (More info: http://soramugi.net)
 # Source Code: https://github.com/id774/automaticruby
 # License: The GPL version 3, or LGPL version 3 (Dual License).
 # Contact: idnanashi@gmail.com


### PR DESCRIPTION
### Motivation

- A prior header-standardization replaced many third-party `Author` lines with `id774`, erasing historical authorship recorded in Git history.  
- The intent is to restore only the historical `Author` names from Git history while preserving the current standardized header format and license/contact metadata.  
- `doc/POLICY.md` needed clarification to ensure future standardization normalizes `774`→`id774` but does not remove or overwrite third-party authors.  

### Description

- Restored historical `Author` header lines in source and spec files by consulting the pre-standardization commit (`ac1715f^`) and replacing `# Author: id774 (More info: http://id774.net)` with the original author names (kept URLs when present) in 42 files.  
- Updated `doc/POLICY.md` to state that `Author` follows the file's Git history, that `774` is normalized to `id774`, and that third-party and multiple authors must not be removed or inferred.  
- Added a short entry to `doc/VERSIONS` recording the correction under the current unreleased version.  
- Changes are header-only (author lines and two documentation files) and preserve `Source Code`, `License`, `Contact`, `Created`, `Updated`, `Copyright` and all modernization work.

### Testing

- Ran an author-audit script comparing current headers to `ac1715f^` which inspected `110` investigated files and validated `66` files were correctly `id774` and `42` required third-party author restoration.  
- Performed `ruby -c` checks across `lib`, `plugins` and `spec` plus `ruby -c` on `Rakefile`, `automatic.gemspec`, and `bin/automatic`, and `sh -n script/build`, all of which passed.  
- Ran `git diff --check` and ensured no whitespace/format problems; the repository is left in a clean working state after the change.  
- `bundle exec rake spec` was not run successfully because `rspec (~> 3.13)` is not installed in the environment, so the full RSpec suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f2f3e1a8083228e661a792c393280)