### PR TITLE
Bump minimum Ruby to 3.3; update CI, docs, Quick Start, example recipe and add tests/plugin example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         # Keep this in step with required_ruby_version in automatic.gemspec
         # and with the supported environment section of README.md.
-        ruby: ['3.2', '3.3', '3.4']
+        ruby: ['3.3', '3.4', '3.5']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -12,12 +12,7 @@ plugins:
   - module: SubscriptionFeed
     config:
       feeds:
-        - https://example.com/feed
-
-  - module: FilterIgnore
-    config:
-      link:
-        - example.net
+        - https://www.ruby-lang.org/en/feeds/news.rss
 
   - module: StorePermalink
     config:
@@ -32,12 +27,15 @@ plugins:
 automatic -c my_recipe.yml
 ```
 
-Fetch some feeds, drop what you do not want, remember what you have already
-seen, and write the rest into a Markdown file: readable by people, reusable by
+Fetch a public feed, remember what has already been seen, and write the new
+items into a Markdown file: readable by people, reusable by
 tools, ready to hand to an AI. Change the last plugin and the same pipeline
 prints to the terminal instead, or downloads the images, or forwards them to
 Fluentd, or writes them to a database. Write your own plugin and it composes
 with all the others.
+
+**[Follow the Quick Start](doc/QUICKSTART.md)** to install the gem, scaffold the
+example, and produce Markdown from the public Ruby news feed.
 
 ---
 
@@ -162,15 +160,14 @@ The full account is [`doc/BASIC_DESIGN.md`](doc/BASIC_DESIGN.md).
 
 ## 4. Supported environment
 
-- **Ruby 3.2 or later.** Tested on 3.2, 3.3 and 3.4.
+- **Ruby 3.3 or later.** Tested on 3.3, 3.4 and 3.5.
 - A Unix-like system. GNU/Linux and macOS are what it is used on. Windows is not
   supported.
 - A compiler, if `nokogiri` or `sqlite3` build from source on your platform.
 
-Ruby 3.2 is the floor: it is the oldest release the dependencies are resolved
-and tested against, and the Ruby that long-term-support distributions still in
-service ship. Nothing older is tested or supported. A newer Ruby than the matrix
-covers is permitted by the gemspec, which sets a lower bound only.
+Ruby 3.3 is the floor: it is the oldest maintained release the dependencies are
+resolved and tested against. Nothing older is tested or supported. A newer Ruby than
+the matrix covers is permitted by the gemspec, which sets a lower bound only.
 
 ## 5. Installation
 
@@ -198,6 +195,8 @@ use the plugin; the table is in [`doc/DEPLOYMENT.md`](doc/DEPLOYMENT.md).
 
 ## 6. Quick start
 
+The complete first-run guide is [`doc/QUICKSTART.md`](doc/QUICKSTART.md).
+
 ```sh
 automatic scaffold
 automatic -c ~/.automatic/config/example/feed2markdown.yml
@@ -207,8 +206,8 @@ automatic -c ~/.automatic/config/example/feed2markdown.yml
 `assets/`, and copies the example Recipes into `~/.automatic/config/example`.
 It never overwrites anything already there.
 
-That Recipe fetches one blog's feed, skips what it has published before, and
-appends the rest to `~/.automatic/markdown/feeds.md`. Run it twice: the second
+That Recipe fetches the public Ruby news feed, skips what it has published
+before, and appends the rest to `~/.automatic/markdown/feeds.md`. Run it twice: the second
 run leaves the file alone, because the store plugin has seen it all. Read the
 file, `grep` it, put it in a repository, or hand it to whatever reads text next.
 `feed2console.yml` beside it is the same pipeline printing to the terminal.
@@ -304,6 +303,9 @@ end
 Save it as `~/.automatic/plugins/filter/short_title.rb` and a Recipe can name
 `FilterShortTitle`. Nothing was registered: the class name and the file path are
 the same fact written twice, and the loader converts between them.
+
+For a smaller complete example, including testing guidance, see
+[`doc/PLUGIN_DEVELOPMENT.md`](doc/PLUGIN_DEVELOPMENT.md).
 
 | Category | Directory | Role |
 | --- | --- | --- |
@@ -550,6 +552,8 @@ this repository. No document here defers to another repository.
 
 | Document | What it holds |
 | --- | --- |
+| [`doc/QUICKSTART.md`](doc/QUICKSTART.md) | The shortest path from installation to a Markdown result |
+| [`doc/PLUGIN_DEVELOPMENT.md`](doc/PLUGIN_DEVELOPMENT.md) | A complete user plugin and practical testing guidance |
 | [`doc/REQUIREMENTS.md`](doc/REQUIREMENTS.md) | What the system is for, what it guarantees, where its responsibility ends |
 | [`doc/BASIC_DESIGN.md`](doc/BASIC_DESIGN.md) | How it is composed: the parts, their responsibilities, the flow of a run |
 | [`doc/PLUGINS.md`](doc/PLUGINS.md) | The Recipe format, the plugin contract, and the catalogue of all 45 plugins |

--- a/automatic.gemspec
+++ b/automatic.gemspec
@@ -38,11 +38,11 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  # Ruby 3.2 is the floor: the oldest release the dependencies below are
+  # Ruby 3.3 is the floor: the oldest maintained release the dependencies are
   # resolved and tested against. This is a lower bound only, so a newer Ruby is
   # permitted before it reaches the CI matrix. See doc/REQUIREMENTS.md
   # section 20.
-  spec.required_ruby_version = '>= 3.2.0'
+  spec.required_ruby_version = '>= 3.3.0'
 
   # Shipped files. Derived from what Git sees, so that the list cannot drift
   # from the repository; the Dir fallback is for building outside a checkout.

--- a/config/feed2markdown.yml
+++ b/config/feed2markdown.yml
@@ -1,4 +1,4 @@
-# Collect, filter, de-duplicate, and leave the result as a Markdown document.
+# Collect, de-duplicate, and leave the result as a Markdown document.
 #
 #   automatic -c ~/.automatic/config/example/feed2markdown.yml
 #
@@ -15,26 +15,11 @@
 #
 #   automatic -c feed2markdown.yml > today.md
 
-global:
-  log:
-    level: info
-
 plugins:
   - module: SubscriptionFeed
     config:
       feeds:
-        - http://blog.id774.net/post/feed/
-      retry: 3
-      interval: 5
-
-  - module: FilterIgnore
-    config:
-      title:
-        - Sponsored
-
-  - module: FilterSort
-    config:
-      sort: asc
+        - https://www.ruby-lang.org/en/feeds/news.rss
 
   - module: StorePermalink
     config:

--- a/doc/BASIC_DESIGN.md
+++ b/doc/BASIC_DESIGN.md
@@ -34,6 +34,13 @@ repository.
 
 ## 3. Composition
 
+A typical run is a short, linear flow. Markdown is one publisher at the edge,
+not a second pipeline representation:
+
+```text
+source plugins -> shared pipeline -> optional filters / stores -> publishers
+```
+
 ```text
 bin/automatic                 process entry point; exit status only
         |

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -28,8 +28,8 @@ nothing to stop.
 
 - A Unix-like system. GNU/Linux and macOS are what this is used on; Windows is
   not supported.
-- **Ruby 3.2 or later.** Check with `ruby -v`. The supported versions are 3.2,
-  3.3 and 3.4.
+- **Ruby 3.3 or later.** Check with `ruby -v`. The supported versions are 3.3,
+  3.4 and 3.5.
 - A build environment for native extensions, because `nokogiri` and `sqlite3`
   may build from source:
 

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -15,6 +15,9 @@ The system these two interfaces belong to is described in
 It stands on its own. Nothing in it is completed by a document kept in another
 repository.
 
+Plugin authors can start with the complete user-plugin example in
+[`PLUGIN_DEVELOPMENT.md`](PLUGIN_DEVELOPMENT.md).
+
 ---
 
 ## 2. The Recipe

--- a/doc/PLUGIN_DEVELOPMENT.md
+++ b/doc/PLUGIN_DEVELOPMENT.md
@@ -1,0 +1,81 @@
+# Plugin Development
+
+A plugin is a small Ruby class with `initialize` and `run`. It needs no registry,
+framework edit or dependency-injection container.
+
+## Naming and location
+
+The class name combines a category and a name. The file path separates them:
+
+```text
+FilterTitlePrefix -> filter/title_prefix.rb
+```
+
+Shipped plugins live under `plugins/`. A user plugin lives under
+`~/.automatic/plugins/` and is found before a shipped plugin with the same name.
+
+## A complete plugin
+
+Create `~/.automatic/plugins/filter/title_prefix.rb`:
+
+```ruby
+module Automatic::Plugin
+  class FilterTitlePrefix
+    def initialize(config, pipeline = [])
+      @config = config || {}
+      @pipeline = pipeline
+    end
+
+    def run
+      prefix = @config['prefix'].to_s
+      @pipeline.each do |feed|
+        next if feed.nil?
+
+        feed.items.each do |item|
+          item.title = "#{prefix}#{item.title}"
+        end
+      end
+      @pipeline
+    end
+  end
+end
+```
+
+Use it in any Recipe:
+
+```yaml
+- module: FilterTitlePrefix
+  config:
+    prefix: "[News] "
+```
+
+No framework source or registry is changed. The loader derives the file path
+from `FilterTitlePrefix` and loads it from the user plugin directory.
+
+## The contract
+
+- Put the class in `Automatic::Plugin`.
+- Choose one existing category: `Subscription`, `CustomFeed`, `Filter`, `Store`,
+  `Provide`, `Notify` or `Publish`.
+- Accept `(config, pipeline)` in `initialize`; tolerate a missing config.
+- Read config by string key, because it comes from YAML.
+- Implement `run` and return the shared pipeline value.
+- Use `Automatic::Log.puts('info', 'message')` for useful operational events.
+  Never log credentials or one noisy line per routine transformation.
+- Require an external gem at the top of the plugin file. A dependency used by
+  one optional plugin does not belong in the framework gemspec.
+
+A source plugin creates feed objects. A Filter or Store changes or narrows them.
+A Publish plugin serializes or sends them, then still returns the pipeline.
+
+## Test it without a network
+
+Construct a pipeline with `Automatic::FeedMaker`, run the class directly and
+assert on its returned items. Use fixed input and temporary directories. The
+default suite must not contact a real host, use a credential or depend on the
+clock. Put an explicitly tagged integration check outside the default suite if
+the plugin must also be exercised against a live service.
+
+The repository's loader specs demonstrate that a plugin placed under the user
+directory is discoverable. The plugin catalogue and complete contract are in
+[`PLUGINS.md`](PLUGINS.md).

--- a/doc/POLICY.md
+++ b/doc/POLICY.md
@@ -72,6 +72,12 @@ general policy would otherwise ask for.
 
 ### 1.3 Design philosophy
 
+- Simple comes before clever. Common work should fit in a short Recipe, and a
+  new abstraction needs a concrete problem the existing plugin contract cannot
+  solve.
+- Documentation examples must run. Supported paths receive maintenance priority
+  over historical integrations that need rework or are unsupported.
+
 - Prefer the smallest change that solves the problem. A pipeline that has run in
   someone's `cron` for a decade has earned the benefit of the doubt.
 - Understand why something exists before replacing it. A constant that looks

--- a/doc/QUICKSTART.md
+++ b/doc/QUICKSTART.md
@@ -1,0 +1,104 @@
+# Quick Start
+
+This guide takes public information through one short Automatic Ruby pipeline
+and leaves it as Markdown. It needs no account, credential, paid service or
+database server.
+
+## 1. Install
+
+Use Ruby 3.3, 3.4 or 3.5 on a Unix-like system:
+
+```sh
+ruby -v
+gem install automatic
+automatic --version
+```
+
+## 2. Create the user directory
+
+```sh
+automatic scaffold
+```
+
+This creates `~/.automatic` and copies the shipped examples to
+`~/.automatic/config/example`. Existing files and directories are not
+overwritten.
+
+## 3. Run the example
+
+The installed example is `config/feed2markdown.yml` in this repository:
+
+```yaml
+plugins:
+  - module: SubscriptionFeed
+    config:
+      feeds:
+        - https://www.ruby-lang.org/en/feeds/news.rss
+
+  - module: StorePermalink
+    config:
+      db: feed2markdown.db
+
+  - module: PublishMarkdown
+    config:
+      file: ~/.automatic/markdown/feeds.md
+      mode: append
+```
+
+Run the scaffolded copy:
+
+```sh
+automatic -c ~/.automatic/config/example/feed2markdown.yml
+```
+
+`SubscriptionFeed` acquires the public Ruby news feed. `StorePermalink` keeps a
+local SQLite record and passes on only unseen items. `PublishMarkdown` appends
+those items to a plain-text document.
+
+## 4. Read the result
+
+```sh
+sed -n '1,80p' ~/.automatic/markdown/feeds.md
+```
+
+Each item is a level-2 heading followed by available metadata and a text body:
+
+```markdown
+## Item title
+
+- Link: <https://example.com/item>
+- Date: 2026-08-14 10:00:00 +0000
+
+Item body.
+```
+
+Run the Recipe again. Items already recorded by `StorePermalink` are not
+appended again.
+
+## 5. Run it from cron
+
+Create the log directory once, then use the absolute path reported by
+`command -v automatic`:
+
+```sh
+mkdir -p ~/.automatic/log
+command -v automatic
+```
+
+```crontab
+0 * * * * /usr/local/bin/automatic -c $HOME/.automatic/config/example/feed2markdown.yml >> $HOME/.automatic/log/feed2markdown.log 2>&1
+```
+
+Automatic Ruby runs once and exits; `cron` supplies the schedule.
+
+## From a source checkout
+
+```sh
+bundle install
+bundle exec bin/automatic scaffold
+bundle exec bin/automatic -c ~/.automatic/config/example/feed2markdown.yml
+```
+
+The Recipe is ordinary YAML. Change the feed URL, insert a supported Filter, or
+change the Markdown path without changing the framework. To write a small
+plugin, continue with [`PLUGIN_DEVELOPMENT.md`](PLUGIN_DEVELOPMENT.md).

--- a/doc/REQUIREMENTS.md
+++ b/doc/REQUIREMENTS.md
@@ -25,9 +25,9 @@ assembled in a configuration file.
 
 ## 3. Purpose
 
-A person has a recurring job that consists of fetching something, deciding which
-parts of it are new or interesting, keeping a record so the same item is not
-handled twice, and sending the result somewhere. Tomorrow they have another job
+A person has a recurring job that consists of acquiring information, processing
+what is useful, optionally persisting a record so it is not handled twice, and
+publishing a portable result. Tomorrow they have another job
 of the same shape with different endpoints. Writing each as a script means
 writing the fetching, the filtering, the de-duplication and the retrying again
 every time.
@@ -439,12 +439,11 @@ plugin knows to upload a local file rather than a remote one.
 
 ## 20. Supported Ruby
 
-- The floor is **Ruby 3.2**: the oldest release the dependency set is resolved
-  and tested against, and the Ruby shipped by long-term-support distributions
-  still in service. Nothing older is tested, and nothing older is supported.
+- The floor is **Ruby 3.3**: the oldest maintained release the dependency set is
+  resolved and tested against. Nothing older is tested or supported.
 - The versions upstream currently maintains are the recommended ones. The
   supported set is what the CI matrix runs, which at the time of writing is
-  3.2, 3.3 and 3.4.
+  3.3, 3.4 and 3.5.
 - The gemspec's `required_ruby_version` is a lower bound and not an upper one, so
   a newer Ruby is permitted before it has been added to the matrix. Adding one
   to the matrix is the act of supporting it.

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -11,6 +11,7 @@ v26.08 (Release Date: TBD)
 - Add the official LGPLv3 license text and include both license texts and the license explanation in the gem.
 - Align source headers and RubyGems metadata with the dual-license policy.
 - Raise the minimum Ruby to 3.2 and test on 3.2 through 3.4, replacing the "after Ruby 1.9" claim.
+- Refresh the supported matrix to maintained Ruby 3.3 through 3.5.
 - Replace Kernel#open with URI.open throughout, so fetching a URL works on Ruby 3, and read local files with File.open.
 - Replace File.exists? with File.exist? in the plugin loader and the Bundler setup.
 - Load Recipes with YAML.safe_load, so a Recipe cannot name a Ruby class to instantiate; aliases stay permitted.
@@ -63,6 +64,8 @@ v26.08 (Release Date: TBD)
 - Place PublishMarkdown in doc/BASIC_DESIGN.md as a serializer at the Publish boundary, keeping Markdown out of the framework, out of the pipeline value and out of any implicit step, and record how the log and a document share standard output.
 - Specify PublishMarkdown in doc/PLUGINS.md: a level-2 heading per item, a metadata list of the fields it carries, content_encoded before description, HTML reduced to text with nokogiri rather than translated, deterministic output, and the file and mode settings.
 - Add config/feed2markdown.yml, collecting a feed, filtering it, de-duplicating with StorePermalink and appending what is new to a Markdown file.
+- Simplify the Quick Start to collect the public Ruby news feed, de-duplicate it and publish Markdown.
+- Add concise Quick Start and plugin development guides whose examples are covered without network access.
 - Document Markdown output for unattended use in doc/DEPLOYMENT.md: the output path, append and overwrite semantics, file permissions, and keeping the log out of the document with global.log.level.
 - State in doc/POLICY.md that converting the pipeline into another representation is a Publish plugin's work and that the result stays inside the plugin.
 - Rewrite the README's opening example and quick start around Markdown output, so that collect, filter, de-duplicate and write a document reads as an ordinary use of the framework.

--- a/spec/config/feed2markdown_spec.rb
+++ b/spec/config/feed2markdown_spec.rb
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+require File.expand_path(File.join(File.dirname(__FILE__), '../spec_helper'))
+
+require 'yaml'
+
+RSpec.describe 'the Quick Start Recipe' do
+  let(:path) { File.join(APP_ROOT, 'config', 'feed2markdown.yml') }
+  let(:recipe) { YAML.safe_load(File.read(path)) }
+
+  it 'uses the short supported pipeline documented by the Quick Start' do
+    modules = recipe.fetch('plugins').map { |plugin| plugin.fetch('module') }
+    expect(modules).to eq %w[SubscriptionFeed StorePermalink PublishMarkdown]
+  end
+
+  it 'uses a public HTTPS source and needs no credential' do
+    source = recipe.fetch('plugins').first.fetch('config').fetch('feeds').first
+    expect(source).to start_with('https://')
+    expect(recipe.to_s).not_to match(/password|token|api[_-]?key/i)
+  end
+
+  it 'names plugins that ship at their loader-derived paths' do
+    recipe.fetch('plugins').each do |plugin|
+      underscored = plugin.fetch('module').underscore
+      category, name = underscored.split('_', 2)
+      expect(File).to exist(File.join(APP_ROOT, 'plugins', category, "#{name}.rb"))
+    end
+  end
+
+  it 'writes the Markdown file described by the Quick Start' do
+    publisher = recipe.fetch('plugins').last.fetch('config')
+    expect(publisher).to include(
+      'file' => '~/.automatic/markdown/feeds.md',
+      'mode' => 'append'
+    )
+  end
+end

--- a/spec/lib/automatic/pipeline_spec.rb
+++ b/spec/lib/automatic/pipeline_spec.rb
@@ -64,6 +64,19 @@ describe Automatic::Pipeline do
         klass.class.should == Class
         klass.new(nil, ["mock"]).run.should == "mock"
       end
+
+      it "loads and runs the documented user filter" do
+        pipeline = AutomaticSpec.generate_pipeline do
+          feed { item "https://example.com/a", "Title" }
+        end
+        Automatic::Pipeline.load_plugin "FilterTitlePrefix"
+        plugin = Automatic::Plugin::FilterTitlePrefix.new(
+          { "prefix" => "[News] " }, pipeline
+        )
+
+        expect(plugin.run).to equal(pipeline)
+        expect(pipeline.first.items.first.title).to eq "[News] Title"
+      end
     end
   end
 end

--- a/spec/user_dir/plugins/filter/title_prefix.rb
+++ b/spec/user_dir/plugins/filter/title_prefix.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+module Automatic::Plugin
+  class FilterTitlePrefix
+    def initialize(config, pipeline = [])
+      @config = config || {}
+      @pipeline = pipeline
+    end
+
+    def run
+      prefix = @config['prefix'].to_s
+      @pipeline.each do |feed|
+        next if feed.nil?
+
+        feed.items.each do |item|
+          item.title = "#{prefix}#{item.title}"
+        end
+      end
+      @pipeline
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

- Raise the supported and tested Ruby floor to the currently maintained release and align the repository docs, gemspec and CI with that decision. 
- Provide a concise Quick Start and a short plugin development guide so users can get running and author plugins without network access. 
- Simplify the shipped example Recipe to use a public HTTPS source and add automated checks that the example is well-formed and self-contained. 

### Description

- Bumped the required Ruby lower bound in `automatic.gemspec` to `>= 3.3.0` and updated the CI matrix in `.github/workflows/ci.yml` to run on Ruby `3.3`, `3.4` and `3.5`. 
- Reworked `README.md`, `doc/*` files (`BASIC_DESIGN.md`, `DEPLOYMENT.md`, `PLUGINS.md`, `POLICY.md`, `REQUIREMENTS.md`, `VERSIONS`) to reflect the new Ruby floor, point at the Quick Start and plugin development guides, and streamline the example usage text. 
- Added `doc/QUICKSTART.md` and `doc/PLUGIN_DEVELOPMENT.md` with a runnable quick path and a complete user-plugin example and testing guidance. 
- Simplified the shipped example Recipe in `config/feed2markdown.yml` to use `https://www.ruby-lang.org/en/feeds/news.rss` and removed unnecessary filters and global logging from the example. 
- Added specs to validate the Quick Start Recipe and plugin loading: `spec/config/feed2markdown_spec.rb`, extended `spec/lib/automatic/pipeline_spec.rb`, and added a user-dir sample plugin at `spec/user_dir/plugins/filter/title_prefix.rb` used by the tests. 

### Testing

- Ran the test suite with `bundle exec rake spec`, including the new `spec/config/feed2markdown_spec.rb` and the added `pipeline` spec, and confirmed the suite passed locally. 
- CI is configured to run the build, CLI checks and `bundle exec rake spec` across Ruby `3.3`, `3.4` and `3.5` via `.github/workflows/ci.yml`. 
- New unit tests assert the Quick Start Recipe modules, HTTPS source, publisher config and that a user plugin placed under the user dir is loadable and transforms the pipeline as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f36995e8c8322b13cf60f992edc33)