### PR TITLE
Fix test isolation: safely restore $stdout and use isolated HOME/DB for specs

### DIFF
--- a/spec/plugins/store/full_text_spec.rb
+++ b/spec/plugins/store/full_text_spec.rb
@@ -18,10 +18,14 @@ describe Automatic::Plugin::StoreFullText do
     @db_filename = "test_full_text.db"
     db_path = Pathname(AutomaticSpec.db_dir).cleanpath+"#{@db_filename}"
     db_path.delete if db_path.exist?
-    tmp_out = StringIO.new()
-    $stdout = tmp_out
-    Automatic::Plugin::StoreFullText.new({"db" => @db_filename}).run
-    $stdout = STDOUT
+    tmp_out = StringIO.new
+    original_stdout = $stdout
+    begin
+      $stdout = tmp_out
+      Automatic::Plugin::StoreFullText.new({"db" => @db_filename}).run
+    ensure
+      $stdout = original_stdout
+    end
     tmp_out.rewind()
     Automatic::Log.puts("info", tmp_out.read())
   end

--- a/spec/plugins/store/permalink_spec.rb
+++ b/spec/plugins/store/permalink_spec.rb
@@ -16,10 +16,14 @@ require 'pathname'
 def db_cleate(db_name)
   db_path = Pathname(AutomaticSpec.db_dir).cleanpath+"#{db_name}"
   db_path.delete if db_path.exist?
-  tmp_out = StringIO.new()
-  $stdout = tmp_out
-  Automatic::Plugin::StorePermalink.new({"db" => db_name}).run
-  $stdout = STDOUT
+  tmp_out = StringIO.new
+  original_stdout = $stdout
+  begin
+    $stdout = tmp_out
+    Automatic::Plugin::StorePermalink.new({"db" => db_name}).run
+  ensure
+    $stdout = original_stdout
+  end
   tmp_out.rewind()
   Automatic::Log.puts("info", tmp_out.read())
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,8 @@ require 'active_support/core_ext/object/blank'
 require 'rspec/collection_matchers'
 require 'rspec/its'
 require 'rss'
+require 'fileutils'
+require 'tmpdir'
 
 require 'automatic'
 
@@ -70,6 +72,17 @@ end
 #   end
 #
 module AutomaticSpec
+  REAL_HOME = ENV['HOME']
+  TEST_HOME = Dir.mktmpdir('automatic-ruby-spec-home')
+  TEST_DB_DIR = File.join(TEST_HOME, '.automatic', 'db')
+  FileUtils.mkdir_p(TEST_DB_DIR)
+  ENV['HOME'] = TEST_HOME
+
+  at_exit do
+    ENV['HOME'] = REAL_HOME
+    FileUtils.remove_entry(TEST_HOME) if File.directory?(TEST_HOME)
+  end
+
   class << self
     # Load a plugin, or report that its dependency is absent.
     #
@@ -101,8 +114,7 @@ module AutomaticSpec
     end
 
     def db_dir
-      dir = File.expand_path('~/.automatic/db')
-      File.directory?(dir) ? dir : File.join(root_dir, 'db')
+      TEST_DB_DIR
     end
   end
 


### PR DESCRIPTION
### Motivation

- Tests were mutating global state (replacing `$stdout` and depending on the real `~/.automatic/db`), which made the suite brittle and could leak changes to the developer environment. 
- Specs need a stable, isolated environment so they can run reliably and without network or credential dependencies.

### Description

- Replace fragile `$stdout` reassignment in specs with a safe `begin`/`ensure` block that stores and restores the original `$stdout` when capturing output in `spec/plugins/store/full_text_spec.rb` and `spec/plugins/store/permalink_spec.rb`.
- Normalize `StringIO.new()` calls to `StringIO.new` for consistency in the updated specs.
- Add `require 'fileutils'` and `require 'tmpdir'` to `spec/spec_helper.rb` and create a temporary `TEST_HOME` with `TEST_DB_DIR`, set `ENV['HOME']` to `TEST_HOME`, and ensure cleanup at exit so tests use an isolated home directory.
- Change `AutomaticSpec.db_dir` to return the temporary `TEST_DB_DIR` so database files are created in the isolated test directory.

### Testing

- Ran the test suite with `bundle exec rake spec`, and the specs completed successfully. 
- No network-tagged specs were run by default due to existing filters, so only offline unit specs were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f3c6f482c8322a81a2c9a9e6ec146)