### PR TITLE
Improve plugin directory documentation with detailed descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,8 +596,13 @@ Two rules worth knowing before you start:
 │       ├── environment.rb   Bundler setup for a source checkout
 │       └── version.rb
 ├── plugins/                 The shipped plugins, one directory per category
-│   ├── subscription/  custom_feed/  filter/
-│   └── store/  provide/  notify/  publish/
+│   ├── subscription/        Acquire from outside
+│   ├── custom_feed/         Build a feed from a source that is not one
+│   ├── filter/              Select, reorder, rewrite
+│   ├── store/               Persist, and drop what was seen before
+│   ├── provide/             Emit the payload elsewhere
+│   ├── notify/              Send a notification
+│   └── publish/             Send the result out, print it, or write it as a document
 ├── config/                  Example Recipes; scaffold copies these out
 ├── assets/siteinfo/         Data files plugins read
 ├── db/                      Fallback for SQLite files when ~/.automatic/db is absent


### PR DESCRIPTION
## Summary
Enhanced the README.md documentation for the plugins directory structure by adding clear, descriptive explanations for each plugin category.

## Changes
- Expanded the plugins directory listing from a compact single-line format to a multi-line format with individual descriptions
- Added descriptive text for each plugin category:
  - `subscription/`: Acquire from outside
  - `custom_feed/`: Build a feed from a source that is not one
  - `filter/`: Select, reorder, rewrite
  - `store/`: Persist, and drop what was seen before
  - `provide/`: Emit the payload elsewhere
  - `notify/`: Send a notification
  - `publish/`: Send the result out, print it, or write it as a document

## Details
This documentation improvement makes it easier for users and contributors to understand the purpose and responsibility of each plugin category at a glance, reducing the need to dig into code or additional documentation to understand the plugin architecture.

https://claude.ai/code/session_018xrChxz6rp847KdZTfYkCJ