### PR TITLE
Skip CI workflows for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ name: CI
 on:
   push:
     branches: ['**']
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -20,7 +20,13 @@ name: Optional plugin dependencies
 on:
   push:
     branches: ['**']
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflows to skip CI runs when only documentation files are modified, reducing unnecessary workflow executions and improving CI efficiency.

## Key Changes
- Added `paths-ignore` configuration to the CI workflow (`ci.yml`) to skip runs when only Markdown files or files in the `doc/` directory are changed
- Added `paths-ignore` configuration to the plugins workflow (`plugins.yml`) with the same exclusion patterns
- Both `push` and `pull_request` events are configured to respect these path filters

## Implementation Details
The workflows now ignore changes to:
- All Markdown files (`**/*.md`)
- All files in the `doc/` directory (`doc/**`)

This prevents unnecessary CI runs when contributors update README files, documentation, or other non-code assets, while still running tests for any actual code changes.

https://claude.ai/code/session_015g5cnn9nyj6oU5gbhX3SVz