### PR TITLE
Clarify versioning policy for pre-release repositories

### DIFF
--- a/doc/POLICY.md
+++ b/doc/POLICY.md
@@ -746,6 +746,11 @@ agree rather than asserting a literal.
   the entry already standing at the top of `doc/VERSIONS`.
 - An unreleased entry carries `(Release Date: TBD)`. Replacing that with the
   date is the release itself, and is not a change to record inside the entry.
+- **A repository that has not yet made its first release is in its initial
+  construction stage**, and that stage takes no entry here. The work of building
+  up to the first release is not accumulated in `doc/VERSIONS` one by one: the
+  file is the record of released versions, not of the construction that precedes
+  the first of them, and its first entry is written when that release is made.
 - **A series of changes made on one day is one version**, not several. Do not
   split a day's work across version numbers.
 - **A version that actually existed is never merged into another**, even when it


### PR DESCRIPTION
## Summary
Updated the versioning policy documentation to clarify how repositories in their initial construction stage (before the first release) should handle version entries.

## Changes
- Added explicit guidance that repositories which have not yet made their first release should not maintain entries in `doc/VERSIONS` during their initial construction phase
- Clarified that `doc/VERSIONS` is a record of released versions, not the construction work leading up to the first release
- Specified that the first entry in `doc/VERSIONS` should be written when the first release is made

## Details
This policy clarification helps new projects understand that they should not attempt to track pre-release development in the versioning file. The file's purpose is to document released versions and their changes, not to accumulate incremental changes during the initial development phase before any release exists.

https://claude.ai/code/session_014Q4JqJ59yu41uBmxVngoVj