### PR TITLE
CLI: report clear error when inspect finds no feed and add spec

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -6,6 +6,7 @@ v26.08 (Release Date: TBD)
 - Support Ruby 3.3 through 4.0 and modernize the codebase for current Ruby and maintained library APIs, validating representative versions in CI.
 - Harden Recipe loading with safe YAML parsing, structural validation and framework-specific errors.
 - Restructure the CLI with help and version options, predictable error reporting and documented exit statuses.
+- Report a clear CLI error when feed inspection discovers no feed instead of raising an internal exception.
 - Verify TLS certificates when publishing to Instapaper instead of accepting an unverified connection.
 - Modernize gem packaging and dependency policy, separating core requirements from optional plugin dependencies so that an installation can be minimal, complete or extended one plugin at a time, and excluding development and generated files.
 - Classify every shipped plugin by its current support status rather than simulating obsolete services in tests.

--- a/lib/automatic/cli.rb
+++ b/lib/automatic/cli.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Aug 14, 2026
-# Updated::     Aug 14, 2026
+# Updated::     Aug 19, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 #
 # Everything that belongs to being a command: option parsing, the subcommands,
@@ -218,6 +218,8 @@ module Automatic
       require 'pp'
       url = argv.shift || missing_argument('inspect')
       feeds = Feedbag.find(url)
+      raise Automatic::Error, "no feed found at #{url}" if feeds.empty?
+
       @stdout.puts feeds.pretty_inspect
       @stdout.puts Automatic::FeedParser.get_url(feeds.pop).pretty_inspect
     end

--- a/spec/lib/automatic/cli_spec.rb
+++ b/spec/lib/automatic/cli_spec.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Aug 14, 2026
-# Updated::     Aug 14, 2026
+# Updated::     Aug 19, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 
 require File.expand_path(File.join(File.dirname(__FILE__), '../../spec_helper'))
@@ -77,6 +77,18 @@ describe Automatic::CLI do
       path = File.join(APP_ROOT, "test", "fixtures", "sampleOPML.xml")
       expect(run("opmlparser", path)).to eq Automatic::CLI::EXIT_SUCCESS
       expect(out.string).not_to be_empty
+    end
+  end
+
+  describe "the inspect subcommand" do
+    it "fails cleanly when no feed is discovered" do
+      stub_const("Feedbag", Class.new)
+      allow(Automatic).to receive(:require_optional)
+      allow(Feedbag).to receive(:find).and_return([])
+
+      expect(run("inspect", "https://example.com/")).to eq Automatic::CLI::EXIT_FAILURE
+      expect(err.string).to match(%r{no feed found at https://example\.com/})
+      expect(out.string).to be_empty
     end
   end
 


### PR DESCRIPTION
### Motivation

- The `inspect` subcommand currently raises an internal exception when feed autodiscovery returns no feeds, which is not friendly for CLI users.

### Description

- Make `inspect_url` raise `Automatic::Error` with a clear message when `Feedbag.find` returns an empty list by adding `raise Automatic::Error, "no feed found at #{url}" if feeds.empty?`.
- Add a spec in `spec/lib/automatic/cli_spec.rb` that stubs `Feedbag.find` to return `[]` and asserts the command returns `EXIT_FAILURE`, emits the expected error text, and produces no stdout.
- Update `doc/VERSIONS` to document the new behavior and bump file header update timestamps in the modified source and spec files.

### Testing

- Ran `rspec spec/lib/automatic/cli_spec.rb` and the suite containing the new `inspect` test passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a858199106883228fd2af2256936e8e)