### PR TITLE
Validate presence of host for HTTP/HTTPS URLs in Automatic::Http

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -7,6 +7,7 @@ v26.08 (Release Date: TBD)
 - Harden Recipe loading with safe YAML parsing, structural validation and framework-specific errors.
 - Restructure the CLI with help and version options, predictable error reporting and documented exit statuses.
 - Report a clear CLI error when feed inspection discovers no feed instead of raising an internal exception.
+- Reject HTTP and HTTPS URLs without a host before attempting a network request.
 - Verify TLS certificates when publishing to Instapaper instead of accepting an unverified connection.
 - Modernize gem packaging and dependency policy, separating core requirements from optional plugin dependencies so that an installation can be minimal, complete or extended one plugin at a time, and excluding development and generated files.
 - Classify every shipped plugin by its current support status rather than simulating obsolete services in tests.

--- a/lib/automatic/http.rb
+++ b/lib/automatic/http.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Aug 15, 2026
-# Updated::     Aug 15, 2026
+# Updated::     Aug 21, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 #
 # One way in for everything the plugins fetch over HTTP.
@@ -78,6 +78,9 @@ module Automatic
         parsed = parse(string)
         unless SCHEMES.include?(parsed.scheme)
           raise ArgumentError, "not an HTTP or HTTPS URL: #{string}"
+        end
+        unless parsed.host
+          raise ArgumentError, "HTTP or HTTPS URL has no host: #{string}"
         end
 
         parsed.normalize

--- a/spec/lib/automatic/http_spec.rb
+++ b/spec/lib/automatic/http_spec.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Aug 15, 2026
-# Updated::     Aug 15, 2026
+# Updated::     Aug 21, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 
 require File.expand_path(File.dirname(__FILE__) + '../../../spec_helper')
@@ -48,6 +48,13 @@ describe Automatic::Http do
     it 'refuses a string that is not a URL at all' do
       lambda { Automatic::Http.uri('invalid_url') }.should raise_error(ArgumentError)
     end
+
+    %w[http:example.com https:/feed].each do |url|
+      it "refuses #{url} without a host" do
+        lambda { Automatic::Http.uri(url) }.
+          should raise_error(ArgumentError, /has no host/)
+      end
+    end
   end
 
   describe '.fetchable?' do
@@ -57,6 +64,7 @@ describe Automatic::Http do
 
     it 'answers false rather than raising for one it will not' do
       Automatic::Http.fetchable?('file:///etc/passwd').should be false
+      Automatic::Http.fetchable?('https:/feed').should be false
       Automatic::Http.fetchable?(nil).should be false
     end
   end


### PR DESCRIPTION
### Motivation
- Ensure the HTTP helper refuses malformed HTTP/HTTPS strings that contain no host so the framework does not attempt an unintended network request or produce unclear internal errors.

### Description
- Add a host presence check to `Automatic::Http.uri` that raises `ArgumentError` with a clear message when an `http`/`https` URL has no host, and normalize the parsed URI as before.
- Add spec coverage in `spec/lib/automatic/http_spec.rb` for URLs without a host and update `fetchable?` expectations accordingly.
- Update `doc/VERSIONS` and file timestamps to reflect the change.

### Testing
- Ran `rspec spec/lib/automatic/http_spec.rb` to exercise the `Automatic::Http` behavior and the new examples, and the test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a885c95a43c8322ac1a2f607037022b)