### PR TITLE
docs: fix residual inconsistencies from the SSOT cleanup

### DIFF
--- a/doc/AI_TUTORIAL.md
+++ b/doc/AI_TUTORIAL.md
@@ -166,11 +166,12 @@ A Recipe that relies on full article bodies should supply siteinfo for the
 sites it relies on under `~/.automatic/assets/siteinfo/`, rather than treating
 the bundled snapshot as a guarantee of coverage.
 
-Where no record matches, the plugin leaves the item exactly as it arrived, and
-the run continues. That is the behaviour to rely on and also the reason the
-document above holds a title, a link and a date per article and no body: an
-index page read without a `description_selector` carries no description for
-`FilterFullFeed` to have improved on.
+Where no record matches, the plugin leaves the item exactly as it arrived and
+the run continues. If the index page also provides no description, that item
+therefore has metadata but no article body. If a bundled or user-supplied
+siteinfo record does match, `FilterFullFeed` may replace the description with
+the selected article body. The tutorial relies on that conditional behavior,
+not on either outcome being guaranteed for a particular site.
 
 Text can enter these items from the index page or from the article page,
 and both are
@@ -418,9 +419,9 @@ in a Recipe they are interchangeable at the same position:
       interval: 2
 ```
 
-Nothing before or after the swapped entry changes. `token`, `model` and `prompt`
-are required by all four; `max_tokens` exists only for Claude, because that API
-requires it. Model names move with the services, so take them from the provider
+Nothing before or after the swapped entry changes. `token`, `model` and
+`prompt` are shared required settings of the AI filters; `max_tokens` exists
+only for Claude because that API requires it. Model names move with the services, so take them from the provider
 you are using rather than from this document, and see
 [`PLUGINS.md`](PLUGINS.md) section 6.3 for each plugin's endpoint,
 authentication and answer handling.

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -1249,9 +1249,9 @@ for new integrations, and authenticates with the token as a bearer token.
 | `retry` | integer | Attempts after a failure. Default `0`. |
 | `interval` | integer | Seconds between attempts. Default `0`. |
 
-The endpoint is fixed by this plugin rather than exposed as a setting, an operator has no version of this
-plugin that talks to a different host, and a setting for it would be a way to
-send the token somewhere else. The answer is read out of the typed `output`
+The endpoint is fixed by this plugin rather than exposed as a setting. An
+operator has no version of this plugin that talks to a different host, and a
+setting for the endpoint would provide a way to send the token somewhere else. The answer is read out of the typed `output`
 array, from the `output_text` of the assistant's message.
 
 ```yaml
@@ -1313,7 +1313,7 @@ URL and out of anything that logs one.
 | Key | Type | Meaning |
 | --- | --- | --- |
 | `token` | string | Gemini API key, sent as `x-goog-api-key`. Required. |
-| `model` | string | Model name, bare — `gemini-3.5-flash`, not `models/gemini-3.5-flash`. Required. |
+| `model` | string | Bare model name without the `models/` prefix. Required. |
 | `prompt` | string | The instruction, sent as `system_instruction`. Required. |
 | `retry` | integer | Attempts after a failure. Default `0`. |
 | `interval` | integer | Seconds between attempts. Default `0`. |


### PR DESCRIPTION
## Summary

Follow-up to #164, which is already merged. Fixes four spots that cleanup missed or left inconsistent:

- `doc/AI_TUTORIAL.md`: "are required by all four" restated the AI filter count when describing shared required settings; now says "shared required settings of the AI filters" without a count.
- `doc/PLUGINS.md`: the FilterGemini `model` setting row hardcoded `gemini-3.5-flash` as an example of the bare-name format; now describes the bare-name requirement without naming a specific current model.
- `doc/AI_TUTORIAL.md`: a paragraph asserted the tutorial's document "holds ... no body" unconditionally, contradicting the match/no-match behavior described in the paragraph immediately above it. Now states both outcomes conditionally.
- `doc/PLUGINS.md`: a run-on sentence describing FilterOpenAI's fixed endpoint is now two grammatically correct sentences.

Only `doc/AI_TUTORIAL.md` and `doc/PLUGINS.md` changed. No runtime behavior, dependency, version, or release metadata changed.

## Test plan

- [x] `grep -n "all four" doc/AI_TUTORIAL.md` — no output
- [x] `grep -n "gemini-3.5-flash" doc/PLUGINS.md` — no output
- [x] `grep -n "document above holds a title, a link and a date per article and no body" doc/AI_TUTORIAL.md` — no output
- [x] `git diff --check` — clean
- [x] `git diff --name-only` — only `doc/AI_TUTORIAL.md` and `doc/PLUGINS.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLHzPf9DKeS5LspxvW5eB)_