### PR TITLE
Require the first version to read only "Initial release."

### DIFF
--- a/doc/POLICY.md
+++ b/doc/POLICY.md
@@ -889,6 +889,8 @@ the version history records what it amounts to.
   level of detail predates these rules.
 - `doc/VERSIONS` carries these guidelines again at its foot, and an entry
   written into it follows the limit recorded there.
+- The first entry, at the lowest version `doc/VERSIONS` reaches, reads only
+  `Initial release.` and nothing else.
 
 ### 10.5 The historical record
 

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -166,7 +166,7 @@ v12.02.1 (2012-02-25)
 
 v12.02 (2012-02-18)
 -------------------
-- First release: the scratch of this script, with a plugin existing only for Hatena Bookmark.
+- Initial release.
 
 
 Notes on this record
@@ -208,3 +208,5 @@ Version History Guidelines
   a date.
 - This file records the history of the repository. A change that is not
   observable from outside does not need an entry here.
+- The first entry, at the lowest version this file reaches, reads only
+  "Initial release." and nothing else.


### PR DESCRIPTION
## Summary
Follow-up to #172 (merged), rebased onto current master since that PR only carried the two-line-limit commit:
- Add a rule to `doc/POLICY.md`: the `doc/VERSIONS` entry at the lowest version reads only `Initial release.` and nothing else.
- Apply it to the genuine first entry, `v12.02`, which previously carried other wording.

## Test plan
- [x] Re-scanned `doc/VERSIONS`; 0 bullets exceed two physical lines and the first entry now reads only "Initial release."
- Documentation-only change; no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrTUHxoev25aExf2UTAnHM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrTUHxoev25aExf2UTAnHM)_