### PR TITLE
Fix file URI and CLI input boundary handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,10 +62,11 @@ group :plugins, :autodiscovery, optional: true do
 end
 
 # The plugins below are Supported (external): each needs a service or a command
-# the operator provides, and their specs exercise it rather than a double. They
-# are deliberately outside the `plugins` group, so that installing that group
-# leaves the suite runnable with nothing else set up. Select one of these by
-# its own name when you have what it talks to.
+# the operator provides for real use. They are deliberately outside the
+# `plugins` group, because installing all of their client gems is not useful
+# without those external systems. Their specs verify the local side of each
+# integration with doubles where appropriate. Select one by its own name when
+# you have what it talks to.
 group :memcached, optional: true do
   gem 'dalli'             # PublishMemcached, with a memcached server
 end

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -1577,12 +1577,14 @@ headline edited between runs no longer republishes the article.
 
 #### StoreFile — **Supported**
 
-`store/file.rb`. Downloads what each link points at and rewrites the link to a
-`file://` URI, which is how `PublishAmazonS3` later knows it has a local file.
+`store/file.rb`. Downloads what each link points at and rewrites the link to an
+absolute `file:` URI for the saved file, which is how `PublishAmazonS3` later
+knows it has a local file. URI-reserved characters in the saved path are
+percent-encoded.
 
 | Key | Type | Meaning |
 | --- | --- | --- |
-| `path` | string | Directory to save into; created if absent. Required. |
+| `path` | string | Directory to save into; relative paths use the process working directory; created if absent. Required. |
 | `retry` | integer | Attempts after the first. Default `0`. |
 | `interval` | integer | Seconds between downloads. Default `0`. |
 | `access_key` | string | S3 only. Omit to use the SDK's own credential chain. |
@@ -1881,8 +1883,9 @@ timeout, so an unanswered request ends rather than hanging a `cron` job.
 
 #### PublishAmazonS3 — **Supported (external)**
 
-`publish/amazon_s3.rb`. Uploads files whose link is a `file://` URI to S3,
-normally after `StoreFile`.
+`publish/amazon_s3.rb`. Uploads files whose link is a `file:` URI to S3,
+normally after `StoreFile`. A percent-encoded URI path is decoded back to the
+local filesystem path before upload.
 
 | Key | Type | Meaning |
 | --- | --- | --- |

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -10,6 +10,7 @@ v26.09 (Release Date: TBD)
 - Preserve nil-link pipeline items and remove SubscriptionText placeholder
   title and link values.
 - Preserve SubscriptionText TSV column positions and ignore empty input rows.
+- Preserve local file paths when StoreFile hands file URIs to PublishAmazonS3.
 
 v26.08 (2026-08-22)
 -------------------

--- a/lib/automatic/cli.rb
+++ b/lib/automatic/cli.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Aug 14, 2026
-# Updated::     Sep  6, 2026
+# Updated::     Sep  9, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 #
 # Everything that belongs to being a command: option parsing, the subcommands,
@@ -208,7 +208,17 @@ module Automatic
       require 'automatic/feed_parser'
       require 'pp'
       url = argv.shift || missing_argument('feedparser')
+      validate_fetch_url(url)
       @stdout.puts Automatic::FeedParser.get_url(url).pretty_inspect
+    end
+
+    # Converts only the URL validation failure `Automatic::Http.uri` already
+    # applies into the CLI's ordinary failure path; an unexpected error from
+    # inside FeedParser itself is left to propagate.
+    def validate_fetch_url(url)
+      Automatic::Http.uri(url)
+    rescue ArgumentError, URI::InvalidURIError => e
+      raise Automatic::Error, e.message
     end
 
     def inspect_url(argv)

--- a/plugins/filter/join.rb
+++ b/plugins/filter/join.rb
@@ -87,11 +87,9 @@ module Automatic::Plugin
       item.public_send(name).to_s.strip
     end
 
-    # Built here rather than through FeedMaker.create_pipeline, which drops an
-    # item whose link is nil -- and this item's link is nil deliberately. It is
-    # several articles at once, so there is no page it points at, and putting
-    # the first article's URL there would name a source for text that is not
-    # only from it.
+    # This joined item deliberately has no link. It is several articles at once,
+    # so there is no single page it points at; using the first article's URL would
+    # name a source for text that is not only from it.
     def feed(item_title, item_description)
       RSS::Maker.make('2.0') { |maker|
         maker.channel.title = 'Automatic Ruby'

--- a/plugins/publish/amazon_s3.rb
+++ b/plugins/publish/amazon_s3.rb
@@ -5,12 +5,14 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Feb 24, 2014
-# Updated::     Aug 15, 2026
+# Updated::     Sep  9, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 
 module Automatic::Plugin
   class PublishAmazonS3
     require 'uri'
+
+    FILE_URI_ESCAPER = URI::RFC2396_Parser.new
 
     def initialize(config, pipeline = [])
       @config   = config || {}
@@ -35,13 +37,17 @@ module Automatic::Plugin
 
       uri = URI.parse(feed.link)
       if uri.scheme == 'file'
-        upload(uri.path)
+        upload(file_path(uri))
       else
         Automatic::Log.puts('warn', 'Skip feed due to uri scheme is not file.')
       end
     rescue StandardError => e
       Automatic::Log.puts('error',
                           "Error detected with #{feed.link} in uploading AmazonS3: #{e.message}")
+    end
+
+    def file_path(uri)
+      FILE_URI_ESCAPER.unescape(uri.path.to_s)
     end
 
     def upload(path)

--- a/plugins/store/file.rb
+++ b/plugins/store/file.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Feb 28, 2012
-# Updated::     Aug 15, 2026
+# Updated::     Sep  9, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 
 require 'fileutils'
@@ -17,6 +17,8 @@ module Automatic::Plugin
     # `s3n` is what Recipes written for this plugin use; `s3` is the spelling
     # everything else uses and is accepted as well.
     S3_SCHEMES = %w[s3 s3n].freeze
+
+    FILE_URI_ESCAPER = URI::RFC2396_Parser.new
 
     def initialize(config, pipeline = [])
       @config   = config || {}
@@ -69,7 +71,13 @@ module Automatic::Plugin
       uri = URI.parse(url)
       path = S3_SCHEMES.include?(uri.scheme) ? from_s3(uri) : download(url)
       Automatic::Log.puts('info', "Saved File: #{path}")
-      "file://#{path}"
+      file_uri(path)
+    end
+
+    def file_uri(path)
+      absolute_path = File.absolute_path(path.to_s)
+      escaped_path = FILE_URI_ESCAPER.escape(absolute_path)
+      URI::Generic.build(scheme: 'file', path: escaped_path).to_s
     end
 
     # Only HTTP and HTTPS are fetched: a link arrives from a feed, which is to

--- a/spec/lib/automatic/cli_spec.rb
+++ b/spec/lib/automatic/cli_spec.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Aug 14, 2026
-# Updated::     Sep  6, 2026
+# Updated::     Sep  9, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 
 require File.expand_path(File.join(File.dirname(__FILE__), '../../spec_helper'))
@@ -77,6 +77,50 @@ describe Automatic::CLI do
       path = File.join(APP_ROOT, "test", "fixtures", "sampleOPML.xml")
       expect(run("opmlparser", path)).to eq Automatic::CLI::EXIT_SUCCESS
       expect(out.string).not_to be_empty
+    end
+  end
+
+  describe "the feedparser subcommand" do
+    it "parses a valid HTTP or HTTPS URL" do
+      allow(Automatic::FeedParser).to receive(:get_url).and_return("parsed")
+
+      expect(run("feedparser", "https://example.com/feed")).to eq Automatic::CLI::EXIT_SUCCESS
+      expect(Automatic::FeedParser).to have_received(:get_url).with("https://example.com/feed")
+      expect(out.string).to match(/parsed/)
+      expect(err.string).to be_empty
+    end
+
+    it "rejects a URL whose scheme is not HTTP or HTTPS" do
+      expect(Automatic::FeedParser).not_to receive(:get_url)
+
+      expect(run("feedparser", "file:///etc/passwd")).to eq Automatic::CLI::EXIT_FAILURE
+      expect(out.string).to be_empty
+      expect(err.string).to match(/automatic: not an HTTP or HTTPS URL:/)
+    end
+
+    it "rejects an HTTP or HTTPS URL with no host" do
+      expect(Automatic::FeedParser).not_to receive(:get_url)
+
+      expect(run("feedparser", "https:/feed")).to eq Automatic::CLI::EXIT_FAILURE
+      expect(out.string).to be_empty
+      expect(err.string).to match(/automatic: HTTP or HTTPS URL has no host:/)
+    end
+
+    it "rejects a URL that fails to parse as a URI syntax error" do
+      expect(Automatic::FeedParser).not_to receive(:get_url)
+
+      expect(run("feedparser", "http://[")).to eq Automatic::CLI::EXIT_FAILURE
+      expect(out.string).to be_empty
+      expect(err.string).to match(/\Aautomatic: /)
+    end
+
+    it "propagates an unexpected internal ArgumentError from FeedParser, unconverted" do
+      allow(Automatic::FeedParser).to receive(:get_url)
+        .and_raise(ArgumentError, 'internal feed parser defect')
+
+      expect {
+        run("feedparser", "https://example.com/feed")
+      }.to raise_error(ArgumentError, /internal feed parser defect/)
     end
   end
 

--- a/spec/plugins/publish/amazon_s3_spec.rb
+++ b/spec/plugins/publish/amazon_s3_spec.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Feb 25, 2014
-# Updated::     Aug 15, 2026
+# Updated::     Sep  9, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 
 require File.expand_path(File.dirname(__FILE__) + '../../../spec_helper')
@@ -59,6 +59,25 @@ describe Automatic::Plugin::PublishAmazonS3 do
         plugin.should_not_receive(:s3)
         plugin.run.should have(1).feed
         plugin.send(:target_key, path).should == 'test/tmp/photo.png'
+      end
+    end
+  end
+
+  context 'with a percent-encoded file URI' do
+    it 'decodes the URI path back to the local filesystem path before uploading' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'a photo.png')
+        File.binwrite(path, 'x')
+
+        escaped_path = URI::RFC2396_Parser.new.escape(path)
+        link = URI::Generic.build(scheme: 'file', path: escaped_path).to_s
+
+        plugin = Automatic::Plugin::PublishAmazonS3.new(
+          settings,
+          AutomaticSpec.generate_pipeline { feed { item link } }
+        )
+        plugin.should_receive(:upload).with(path).and_call_original
+        plugin.run.should have(1).feed
       end
     end
   end

--- a/spec/plugins/store/file_spec.rb
+++ b/spec/plugins/store/file_spec.rb
@@ -5,7 +5,7 @@
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com
 # Created::     Mar  4, 2012
-# Updated::     Aug 14, 2026
+# Updated::     Sep  9, 2026
 # Copyright::   Copyright (c) 2012-2026 Automatic Ruby Developers.
 
 require File.expand_path(File.dirname(__FILE__) + '../../../spec_helper')
@@ -85,6 +85,30 @@ describe Automatic::Plugin::StoreFile do
       returned.should have(1).feed
       returned[0].items[0].link.should == "file://#{File.join(dir, 'photo.png')}"
       File.read(File.join(dir, 'photo.png')).should == 'a body'
+    end
+  end
+
+  it "rewrites a relative, space-containing path to an absolute, escaped file URI" do
+    relative_dir = "automatic-store-file-spec #{Process.pid}"
+    FileUtils.mkdir_p(relative_dir)
+    begin
+      Automatic::Http.stub(:read).and_return('a body')
+      instance = Automatic::Plugin::StoreFile.new(
+        { "path" => relative_dir },
+        AutomaticSpec.generate_pipeline { feed { item "https://example.com/a/photo.png" } }
+      )
+
+      returned = instance.run
+      saved_path = File.join(relative_dir, 'photo.png')
+      uri = URI.parse(returned[0].items[0].link)
+
+      uri.scheme.should == 'file'
+      uri.host.to_s.should be_empty
+      uri.to_s.should include('%20')
+      URI::RFC2396_Parser.new.unescape(uri.path).should == File.absolute_path(saved_path)
+      File.read(saved_path).should == 'a body'
+    ensure
+      FileUtils.rm_rf(relative_dir)
     end
   end
 


### PR DESCRIPTION
## Summary

- `StoreFile` now hands `PublishAmazonS3` the actual saved path as an absolute, percent-encoded `file:` URI, instead of concatenating a possibly-relative path onto `file://` (which could be misread as carrying an authority, and could not represent a path containing a space or other URI-reserved character).
- `PublishAmazonS3` now decodes the URI path back to a local filesystem path before uploading, undoing the percent-encoding `StoreFile` applies.
- The `feedparser` subcommand now converts the URL validation failure `Automatic::Http.uri` already applies into the CLI's ordinary failure path (stderr diagnostic, exit `1`), instead of letting it surface as an unprocessed exception with a backtrace.
- `plugins/filter/join.rb`'s comment describing `FeedMaker.create_pipeline`'s nil-link behavior no longer describes a code path this plugin doesn't call; it now just documents why this item's link is nil.
- The `Gemfile` comment for the Supported (external) plugin group no longer claims their specs exercise the external service directly rather than a double, which does not match how those specs are actually written.

## Compatibility

- Recipe format, plugin interface, configuration keys/defaults, and pipeline shape are unchanged.
- No dependency was added, removed, or had its version constraint changed.
- Ruby support (`>= 3.3.0`) and the CI matrix (3.3 / 3.4 / 4.0) are unchanged.
- No unexpected internal exception is blanket-rescued: an internal `ArgumentError` raised from inside `FeedParser.get_url` (after URL validation passes) still propagates unconverted.

## Version History

- The CLI correction is covered by the existing v26.09 "Harden the framework's execution boundary" bullet in `doc/VERSIONS`, which already describes fixing CLI contract drift; no new bullet was added for it.
- The `StoreFile`/`PublishAmazonS3` handoff fix is recorded as one new v26.09 bullet: "Preserve local file paths when StoreFile hands file URIs to PublishAmazonS3."
- No release item was added for the comment-only corrections in `plugins/filter/join.rb` or `Gemfile`, or for the `doc/PLUGINS.md` clarifications.

## Validation

- Targeted specs (`spec/plugins/store/file_spec.rb`, `spec/plugins/publish/amazon_s3_spec.rb`, `spec/lib/automatic/cli_spec.rb`): 45 examples, 0 failures.
- Full default suite (`bundle exec rake spec`): 423 examples, 0 failures (network spec not enabled).
- `gem build automatic.gemspec`: succeeded (version 26.09).
- `require 'automatic'`: loads successfully.
- `bin/automatic --version`: exit 0.
- `bin/automatic --help`: exit 0.
- Manually verified `feedparser` against `file:///etc/passwd`, `https:/feed`, and `http://[`: each exits 1 with a one-line `automatic: ` diagnostic on stderr and empty stdout.
- GitHub Actions Ruby 3.3 / 3.4 / 4.0: pending on this PR; will confirm once CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Zn5VetozA4NmGEUGLGik1

---
_Generated by [Claude Code](https://claude.ai/code/session_017Zn5VetozA4NmGEUGLGik1)_