### PR TITLE
Update id774.net header URL to HTTPS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # -*- mode: ruby; coding: utf-8 -*-
 # Name::        Rakefile
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/automatic.gemspec
+++ b/automatic.gemspec
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        automatic.gemspec
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/bin/automatic
+++ b/bin/automatic
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 # Name::        automatic
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic.rb
+++ b/lib/automatic.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Ruby
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic/cli.rb
+++ b/lib/automatic/cli.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::CLI
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic/environment.rb
+++ b/lib/automatic/environment.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Environment
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic/feed_maker.rb
+++ b/lib/automatic/feed_maker.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::FeedMaker
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic/feed_parser.rb
+++ b/lib/automatic/feed_parser.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::FeedParser
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic/http.rb
+++ b/lib/automatic/http.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Http
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic/log.rb
+++ b/lib/automatic/log.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Log
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic/pipeline.rb
+++ b/lib/automatic/pipeline.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Pipeline
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/lib/automatic/version.rb
+++ b/lib/automatic/version.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::VERSION
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/custom_feed/web.rb
+++ b/plugins/custom_feed/web.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::CustomFeed::Web
 # Description:: Build a feed from the article links of an HTML index page.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/absolute_uri.rb
+++ b/plugins/filter/absolute_uri.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::AbsoluteURI
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/batch.rb
+++ b/plugins/filter/batch.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Batch
 # Description:: Group the whole pipeline into fixed-size item batches.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/claude.rb
+++ b/plugins/filter/claude.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Claude
 # Description:: Replace each item's description with what the Anthropic Claude API answers.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/clear.rb
+++ b/plugins/filter/clear.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Clear
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/description_link.rb
+++ b/plugins/filter/description_link.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::DescriptionLink
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/gemini.rb
+++ b/plugins/filter/gemini.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Gemini
 # Description:: Replace each item's description with what the Google Gemini API answers.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/ignore.rb
+++ b/plugins/filter/ignore.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Ignore
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/image.rb
+++ b/plugins/filter/image.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Image
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/image_source.rb
+++ b/plugins/filter/image_source.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::ImageSource
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/join.rb
+++ b/plugins/filter/join.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Join
 # Description:: Join every item in the pipeline into one item.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/limit.rb
+++ b/plugins/filter/limit.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Limit
 # Description:: Limit the number of items passed by the whole pipeline.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/open_ai.rb
+++ b/plugins/filter/open_ai.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::OpenAI
 # Description:: Replace each item's description with what the OpenAI API answers.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/present.rb
+++ b/plugins/filter/present.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Present
 # Description:: Keep items whose configured fields are all present.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/sakura_ai.rb
+++ b/plugins/filter/sakura_ai.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::SakuraAI
 # Description:: Replace each item's description with what the Sakura AI Engine answers.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/sanitize.rb
+++ b/plugins/filter/sanitize.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Sanitize
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/sort.rb
+++ b/plugins/filter/sort.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Sort
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/filter/tumblr_resize.rb
+++ b/plugins/filter/tumblr_resize.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::TumblrResize
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/notify/ikachan.rb
+++ b/plugins/notify/ikachan.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Notify::Ikachan
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/provide/fluentd.rb
+++ b/plugins/provide/fluentd.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Provide::Fluentd
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/publish/amazon_s3.rb
+++ b/plugins/publish/amazon_s3.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::AmazonS3
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/publish/console.rb
+++ b/plugins/publish/console.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::Console
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/publish/fluentd.rb
+++ b/plugins/publish/fluentd.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::Fluentd
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/publish/hatena_bookmark.rb
+++ b/plugins/publish/hatena_bookmark.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::HatenaBookmark
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/publish/markdown.rb
+++ b/plugins/publish/markdown.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::Markdown
 # Description:: Render the pipeline as a Markdown document, to a file or to standard output.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/publish/memcached.rb
+++ b/plugins/publish/memcached.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::Memcached
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/store/digest.rb
+++ b/plugins/store/digest.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Store::Digest
 # Description:: Drop items whose content has been seen before, by SHA-256 digest.
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/store/file.rb
+++ b/plugins/store/file.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Store::File
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/store/full_text.rb
+++ b/plugins/store/full_text.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Store::FullText
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/store/permalink.rb
+++ b/plugins/store/permalink.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Store::Permalink
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/subscription/feed.rb
+++ b/plugins/subscription/feed.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::SubscriptionFeed
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/subscription/link.rb
+++ b/plugins/subscription/link.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Subscription::Link
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/subscription/tumblr.rb
+++ b/plugins/subscription/tumblr.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Subscription::Tumblr
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/plugins/subscription/xml.rb
+++ b/plugins/subscription/xml.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Subscription::Xml
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/script/build
+++ b/script/build
@@ -12,7 +12,7 @@
 #    script/build          Run the test suite and the CLI checks.
 #    script/build all      Also run the integration recipes by hand.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code:: https://github.com/id774/automaticruby
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/spec/doc/plugins_catalogue_spec.rb
+++ b/spec/doc/plugins_catalogue_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        The plugin catalogue
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/lib/automatic/cli_spec.rb
+++ b/spec/lib/automatic/cli_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::CLI
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/lib/automatic/feed_maker_spec.rb
+++ b/spec/lib/automatic/feed_maker_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::FeedMaker
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/lib/automatic/http_spec.rb
+++ b/spec/lib/automatic/http_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Http
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/lib/automatic/recipe_safety_spec.rb
+++ b/spec/lib/automatic/recipe_safety_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Recipe (loading and refusal)
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/lib/automatic/recipe_spec.rb
+++ b/spec/lib/automatic/recipe_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Auaotmatic::Recipe
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/lib/automatic_spec_helper_spec.rb
+++ b/spec/lib/automatic_spec_helper_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        AutomaticSpec
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/custom_feed/web_spec.rb
+++ b/spec/plugins/custom_feed/web_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::CustomFeed::Web
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/absolute_uri_spec.rb
+++ b/spec/plugins/filter/absolute_uri_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::AbsoluteURI
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/batch_spec.rb
+++ b/spec/plugins/filter/batch_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Batch
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/claude_spec.rb
+++ b/spec/plugins/filter/claude_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Claude
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/clear_spec.rb
+++ b/spec/plugins/filter/clear_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Clear
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/description_link_spec.rb
+++ b/spec/plugins/filter/description_link_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::DescriptionLink
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/full_feed_spec.rb
+++ b/spec/plugins/filter/full_feed_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::FullFeed
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/gemini_spec.rb
+++ b/spec/plugins/filter/gemini_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Gemini
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/ignore_spec.rb
+++ b/spec/plugins/filter/ignore_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Ignore
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/image_spec.rb
+++ b/spec/plugins/filter/image_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Image
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/join_spec.rb
+++ b/spec/plugins/filter/join_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Join
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/limit_spec.rb
+++ b/spec/plugins/filter/limit_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Limit
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/open_ai_spec.rb
+++ b/spec/plugins/filter/open_ai_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::OpenAI
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/present_spec.rb
+++ b/spec/plugins/filter/present_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Present
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/sakura_ai_spec.rb
+++ b/spec/plugins/filter/sakura_ai_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::SakuraAI
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/sanitize_spec.rb
+++ b/spec/plugins/filter/sanitize_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Sanitize
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/sort_spec.rb
+++ b/spec/plugins/filter/sort_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::Sort
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/filter/tumblr_resize_spec.rb
+++ b/spec/plugins/filter/tumblr_resize_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Filter::TumblrResize
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/notify/ikachan_spec.rb
+++ b/spec/plugins/notify/ikachan_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Notify::Ikachan
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/provide/fluentd_spec.rb
+++ b/spec/plugins/provide/fluentd_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Provide::Fluentd
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/publish/amazon_s3_spec.rb
+++ b/spec/plugins/publish/amazon_s3_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::AmazonS3
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/publish/console_spec.rb
+++ b/spec/plugins/publish/console_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::Console
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/publish/fluentd_spec.rb
+++ b/spec/plugins/publish/fluentd_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::Fluentd
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/publish/hatena_bookmark_spec.rb
+++ b/spec/plugins/publish/hatena_bookmark_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::HatenaBookmark
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/publish/markdown_spec.rb
+++ b/spec/plugins/publish/markdown_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::Markdown
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/publish/memcached_spec.rb
+++ b/spec/plugins/publish/memcached_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Publish::Memcached
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/store/digest_spec.rb
+++ b/spec/plugins/store/digest_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Store::Digest
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/store/full_text_spec.rb
+++ b/spec/plugins/store/full_text_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Store::FullText
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/store/permalink_spec.rb
+++ b/spec/plugins/store/permalink_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Store::Permalink
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/subscription/feed_spec.rb
+++ b/spec/plugins/subscription/feed_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Subscription::Feed
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/subscription/link_spec.rb
+++ b/spec/plugins/subscription/link_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Subscription::Link
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/subscription/tumblr_spec.rb
+++ b/spec/plugins/subscription/tumblr_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Subscription::Tumblr
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/plugins/subscription/xml_spec.rb
+++ b/spec/plugins/subscription/xml_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::Subscription::Xml
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Spec
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com

--- a/spec/user_dir/plugins/filter/load_marker.rb
+++ b/spec/user_dir/plugins/filter/load_marker.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Name::        Automatic::Plugin::FilterLoadMarker
-# Author:       id774 (More info: http://id774.net)
+# Author:       id774 (More info: https://id774.net)
 # Source Code:: https://github.com/id774/automaticruby
 # License::     The GPL version 3, or LGPL version 3 (Dual License).
 # Contact::     idnanashi@gmail.com


### PR DESCRIPTION
## Summary

- Mechanically changed `More info: http://id774.net` to `More info: https://id774.net` in file headers (89 files).
- No changes other than the URL scheme (`http` → `https`).
- No version changes.
- No changes to Version History, README, or other documentation (the example text inside `doc/POLICY.md` was intentionally left out of scope).
- No test additions or changes (spec files only had their own header line updated).

## Mandatory Validation (actual results)

- Old notation remaining: PASS (except for 1 example occurrence in `doc/POLICY.md`, which is intentionally out of scope and left unchanged)
- Diffs other than URL scheme: 0 — PASS
- Out-of-scope changes: 0 — PASS
- Version changes: 0 — PASS
- Version History changes: 0 — PASS
- Other documentation changes: 0 — PASS
- Test changes: 0 — PASS
- Dependency changes: 0 — PASS
- `git diff --check`: PASS (0 whitespace errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)