### PR TITLE
Update id774.net URLs in README and LICENSE files

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,5 +718,5 @@ See [`doc/LICENSE.md`](doc/LICENSE.md), [`doc/COPYING`](doc/COPYING) and
 
 Copyright (c) 2012-2026 Automatic Ruby Developers.
 
-Project created by [id774](http://id774.net). Contributors are listed in
+Project created by [id774](https://id774.net). Contributors are listed in
 [`doc/AUTHORS`](doc/AUTHORS).


### PR DESCRIPTION
## Summary

- Mechanically changed `http://id774.net` to `https://id774.net` in README and LICENSE files (1 file: `README.md`).
- No changes other than the URL scheme (`http` → `https`).
- No version changes.
- No changes to Version History, VERSIONS, or CHANGELOG.
- No changes to documentation other than README/LICENSE files.
- No changes to source code, test, dependency, or CI.

## Mandatory Validation (actual results)

- Old notation remaining: 0 — PASS
- Changes outside README/LICENSE files: 0 — PASS
- Diffs other than URL scheme: 0 — PASS
- Version changes: 0 — PASS
- Version History changes: 0 — PASS
- Source code changes: 0 — PASS
- Test changes: 0 — PASS
- Dependency changes: 0 — PASS
- CI changes: 0 — PASS
- `git diff --check`: PASS (0 whitespace errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)