### PR TITLE
Update remaining id774.net test URLs to HTTPS

### DIFF
--- a/spec/plugins/filter/absolute_uri_spec.rb
+++ b/spec/plugins/filter/absolute_uri_spec.rb
@@ -16,20 +16,20 @@ describe Automatic::Plugin::FilterAbsoluteURI do
   context "with feed contain link tag" do
     subject {
       Automatic::Plugin::FilterAbsoluteURI.new({
-        'url' => "http://id774.net/images/",
+        'url' => "https://id774.net/images/",
       },
         AutomaticSpec.generate_pipeline {
           feed {
-            item "http://id774.net/images/link_1.jpg"
+            item "https://id774.net/images/link_1.jpg"
             item "link_2.jpg"
             item "link_3.JPG"
-            item "http://id774.net/images/link_4.png"
+            item "https://id774.net/images/link_4.png"
             item "link_5.jpeg"
-            item "http://id774.net/images/link_6.PNG"
+            item "https://id774.net/images/link_6.PNG"
             item "link_8.gif"
-            item "http://id774.net/images/link_9.GIF"
+            item "https://id774.net/images/link_9.GIF"
             item "link_10.tiff"
-            item "http://id774.net/images/link_11.TIFF"
+            item "https://id774.net/images/link_11.TIFF"
           }})}
 
     describe "#run" do
@@ -38,25 +38,25 @@ describe Automatic::Plugin::FilterAbsoluteURI do
       specify {
         returned = subject.run
         returned[0].items[0].link.
-        should == "http://id774.net/images/link_1.jpg"
+        should == "https://id774.net/images/link_1.jpg"
         returned[0].items[1].link.
-        should == "http://id774.net/images/link_2.jpg"
+        should == "https://id774.net/images/link_2.jpg"
         returned[0].items[2].link.
-        should == "http://id774.net/images/link_3.JPG"
+        should == "https://id774.net/images/link_3.JPG"
         returned[0].items[3].link.
-        should == "http://id774.net/images/link_4.png"
+        should == "https://id774.net/images/link_4.png"
         returned[0].items[4].link.
-        should == "http://id774.net/images/link_5.jpeg"
+        should == "https://id774.net/images/link_5.jpeg"
         returned[0].items[5].link.
-        should == "http://id774.net/images/link_6.PNG"
+        should == "https://id774.net/images/link_6.PNG"
         returned[0].items[6].link.
-        should == "http://id774.net/images/link_8.gif"
+        should == "https://id774.net/images/link_8.gif"
         returned[0].items[7].link.
-        should == "http://id774.net/images/link_9.GIF"
+        should == "https://id774.net/images/link_9.GIF"
         returned[0].items[8].link.
-        should == "http://id774.net/images/link_10.tiff"
+        should == "https://id774.net/images/link_10.tiff"
         returned[0].items[9].link.
-        should == "http://id774.net/images/link_11.TIFF"
+        should == "https://id774.net/images/link_11.TIFF"
       }
     end
   end

--- a/spec/plugins/filter/full_feed_spec.rb
+++ b/spec/plugins/filter/full_feed_spec.rb
@@ -363,7 +363,7 @@ describe Automatic::Plugin::FilterFullFeed do
         },
         AutomaticSpec.generate_pipeline {
           feed {
-            item "http://id774.net", "aaaaaa",
+            item "https://id774.net", "aaaaaa",
             "bbbbbb",
             "Mon, 07 Mar 2011 15:54:11 +0900"
           }})}
@@ -373,14 +373,14 @@ describe Automatic::Plugin::FilterFullFeed do
 
       specify {
         subject.instance_variable_get(:@pipeline)[0].items[0].link.
-        should == "http://id774.net"
+        should == "https://id774.net"
         subject.instance_variable_get(:@pipeline)[0].items[0].description.
         should == "bbbbbb"
 
         subject.run
 
         subject.instance_variable_get(:@pipeline)[0].items[0].link.
-        should == "http://id774.net"
+        should == "https://id774.net"
         subject.instance_variable_get(:@pipeline)[0].items[0].description.
         should == "bbbbbb"
       }
@@ -395,7 +395,7 @@ describe Automatic::Plugin::FilterFullFeed do
         },
         AutomaticSpec.generate_pipeline {
           feed {
-            item "http://id774.net", "cccc",
+            item "https://id774.net", "cccc",
             "ddddd",
             "Mon, 07 Mar 2011 15:54:11 +0900"
           }})}
@@ -420,14 +420,14 @@ describe Automatic::Plugin::FilterFullFeed do
 
       specify {
         subject.instance_variable_get(:@pipeline)[0].items[0].link.
-        should == "http://id774.net"
+        should == "https://id774.net"
         subject.instance_variable_get(:@pipeline)[0].items[0].description.
         should == "ddddd"
 
         subject.run
 
         subject.instance_variable_get(:@pipeline)[0].items[0].link.
-        should == "http://id774.net"
+        should == "https://id774.net"
         subject.instance_variable_get(:@pipeline)[0].items[0].description.
         should == "ddddd"
       }

--- a/spec/plugins/filter/image_spec.rb
+++ b/spec/plugins/filter/image_spec.rb
@@ -18,18 +18,18 @@ describe Automatic::Plugin::FilterImage do
       Automatic::Plugin::FilterImage.new({},
         AutomaticSpec.generate_pipeline {
           feed {
-            item "http://id774.net/images/link_1.jpg"
-            item "http://id774.net/images/link_2.jpg"
-            item "http://id774.net/images/link_3.JPG"
-            item "http://id774.net/images/link_4.png"
-            item "http://id774.net/images/link_5.jpeg"
-            item "http://id774.net/images/link_6.PNG"
-            item "http://id774.net/images/link_7.jpega"
-            item "http://id774.net/images/link_8.gif"
-            item "http://id774.net/images/link_9.GIF"
-            item "http://id774.net/images/link_10.tiff"
+            item "https://id774.net/images/link_1.jpg"
+            item "https://id774.net/images/link_2.jpg"
+            item "https://id774.net/images/link_3.JPG"
+            item "https://id774.net/images/link_4.png"
+            item "https://id774.net/images/link_5.jpeg"
+            item "https://id774.net/images/link_6.PNG"
+            item "https://id774.net/images/link_7.jpega"
+            item "https://id774.net/images/link_8.gif"
+            item "https://id774.net/images/link_9.GIF"
+            item "https://id774.net/images/link_10.tiff"
             item nil
-            item "http://id774.net/images/link_11.TIFF"
+            item "https://id774.net/images/link_11.TIFF"
           }})}
 
     describe "#run" do
@@ -38,29 +38,29 @@ describe Automatic::Plugin::FilterImage do
       specify {
         returned = subject.run
         returned[0].items[0].link.
-        should == "http://id774.net/images/link_1.jpg"
+        should == "https://id774.net/images/link_1.jpg"
         returned[0].items[1].link.
-        should == "http://id774.net/images/link_2.jpg"
+        should == "https://id774.net/images/link_2.jpg"
         returned[0].items[2].link.
-        should == "http://id774.net/images/link_3.JPG"
+        should == "https://id774.net/images/link_3.JPG"
         returned[0].items[3].link.
-        should == "http://id774.net/images/link_4.png"
+        should == "https://id774.net/images/link_4.png"
         returned[0].items[4].link.
-        should == "http://id774.net/images/link_5.jpeg"
+        should == "https://id774.net/images/link_5.jpeg"
         returned[0].items[5].link.
-        should == "http://id774.net/images/link_6.PNG"
+        should == "https://id774.net/images/link_6.PNG"
         returned[0].items[6].link.
         should be_nil
         returned[0].items[7].link.
-        should == "http://id774.net/images/link_8.gif"
+        should == "https://id774.net/images/link_8.gif"
         returned[0].items[8].link.
-        should == "http://id774.net/images/link_9.GIF"
+        should == "https://id774.net/images/link_9.GIF"
         returned[0].items[9].link.
-        should == "http://id774.net/images/link_10.tiff"
+        should == "https://id774.net/images/link_10.tiff"
         returned[0].items[10].link.
         should be_nil
         returned[0].items[11].link.
-        should == "http://id774.net/images/link_11.TIFF"
+        should == "https://id774.net/images/link_11.TIFF"
       }
     end
   end

--- a/spec/plugins/provide/fluentd_spec.rb
+++ b/spec/plugins/provide/fluentd_spec.rb
@@ -24,7 +24,7 @@ describe Automatic::Plugin::ProvideFluentd do
   }
 
   let(:pipeline) {
-    [Automatic::FeedMaker.content_provide('http://id774.net/test/xml/data',
+    [Automatic::FeedMaker.content_provide('https://id774.net/test/xml/data',
                                           'test1' => 'test2', 'test3' => 'test4')]
   }
 

--- a/spec/plugins/store/file_spec.rb
+++ b/spec/plugins/store/file_spec.rb
@@ -20,7 +20,7 @@ describe Automatic::Plugin::StoreFile do
       instance = Automatic::Plugin::StoreFile.new(
         { "path" => dir },
         AutomaticSpec.generate_pipeline {
-          feed { item "http://id774.net/test/store/rss" }
+          feed { item "https://id774.net/test/store/rss" }
         }
       )
       instance.run.should have(1).feed

--- a/spec/plugins/store/permalink_spec.rb
+++ b/spec/plugins/store/permalink_spec.rb
@@ -70,17 +70,17 @@ describe Automatic::Plugin::StorePermalink do
     instance = Automatic::Plugin::StorePermalink.new({"db" => @db_filename},
       AutomaticSpec.generate_pipeline {
         feed {
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_2.jpg"
-          item "http://id774.net/images/link_3.JPG"
-          item "http://id774.net/images/link_4.png"
-          item "http://id774.net/images/link_5.jpeg"
-          item "http://id774.net/images/link_6.PNG"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_2.jpg"
+          item "https://id774.net/images/link_3.JPG"
+          item "https://id774.net/images/link_4.png"
+          item "https://id774.net/images/link_5.jpeg"
+          item "https://id774.net/images/link_6.PNG"
           item nil
-          item "http://id774.net/images/link_8.gif"
-          item "http://id774.net/images/link_9.GIF"
-          item "http://id774.net/images/link_10.tiff"
-          item "http://id774.net/images/link_11.TIFF"
+          item "https://id774.net/images/link_8.gif"
+          item "https://id774.net/images/link_9.GIF"
+          item "https://id774.net/images/link_10.tiff"
+          item "https://id774.net/images/link_11.TIFF"
         }
       }
     )
@@ -97,17 +97,17 @@ describe Automatic::Plugin::StorePermalink do
     instance = Automatic::Plugin::StorePermalink.new({"db" => @db_filename},
       AutomaticSpec.generate_pipeline {
         feed {
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_3.JPG"
-          item "http://id774.net/images/link_4.png"
-          item "http://id774.net/images/link_5.jpeg"
-          item "http://id774.net/images/link_6.PNG"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_3.JPG"
+          item "https://id774.net/images/link_4.png"
+          item "https://id774.net/images/link_5.jpeg"
+          item "https://id774.net/images/link_6.PNG"
           item nil
-          item "http://id774.net/images/link_8.gif"
-          item "http://id774.net/images/link_9.GIF"
-          item "http://id774.net/images/link_10.tiff"
-          item "http://id774.net/images/link_11.TIFF"
+          item "https://id774.net/images/link_8.gif"
+          item "https://id774.net/images/link_9.GIF"
+          item "https://id774.net/images/link_10.tiff"
+          item "https://id774.net/images/link_11.TIFF"
         }
       }
     )
@@ -124,17 +124,17 @@ describe Automatic::Plugin::StorePermalink do
     instance = Automatic::Plugin::StorePermalink.new({"db" => @db_filename},
       AutomaticSpec.generate_pipeline {
         feed {
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_3.JPG"
-          item "http://id774.net/images/link_4.png"
-          item "http://id774.net/images/link_5.jpeg"
-          item "http://id774.net/images/link_6.PNG"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_3.JPG"
+          item "https://id774.net/images/link_4.png"
+          item "https://id774.net/images/link_5.jpeg"
+          item "https://id774.net/images/link_6.PNG"
           item nil
-          item "http://id774.net/images/link_8.gif"
-          item "http://id774.net/images/link_9.GIF"
-          item "http://id774.net/images/link_10.tiff"
-          item "http://id774.net/images/link_11.TIFF"
+          item "https://id774.net/images/link_8.gif"
+          item "https://id774.net/images/link_9.GIF"
+          item "https://id774.net/images/link_10.tiff"
+          item "https://id774.net/images/link_11.TIFF"
         }
       }
     )
@@ -147,17 +147,17 @@ describe Automatic::Plugin::StorePermalink do
     instance = Automatic::Plugin::StorePermalink.new({"db" => @db_filename},
       AutomaticSpec.generate_pipeline {
         feed {
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_3.JPG"
-          item "http://id774.net/images/link_4.png"
-          item "http://id774.net/images/link_5.jpeg"
-          item "http://id774.net/images/link_6.PNG"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_3.JPG"
+          item "https://id774.net/images/link_4.png"
+          item "https://id774.net/images/link_5.jpeg"
+          item "https://id774.net/images/link_6.PNG"
           item nil
-          item "http://id774.net/images/link_8.gif"
-          item "http://id774.net/images/link_9.GIF"
-          item "http://id774.net/images/link_10.tiff"
-          item "http://id774.net/images/link_11.TIFF"
+          item "https://id774.net/images/link_8.gif"
+          item "https://id774.net/images/link_9.GIF"
+          item "https://id774.net/images/link_10.tiff"
+          item "https://id774.net/images/link_11.TIFF"
         }
       }
     )
@@ -174,17 +174,17 @@ describe Automatic::Plugin::StorePermalink do
     instance = Automatic::Plugin::StorePermalink.new({"db" => @db_filename},
       AutomaticSpec.generate_pipeline {
         feed {
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_3.JPG"
-          item "http://id774.net/images/link_4.png"
-          item "http://id774.net/images/link_5.jpeg"
-          item "http://id774.net/images/link_6.PNG"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_3.JPG"
+          item "https://id774.net/images/link_4.png"
+          item "https://id774.net/images/link_5.jpeg"
+          item "https://id774.net/images/link_6.PNG"
           item nil
-          item "http://id774.net/images/link_8.gif"
-          item "http://id774.net/images/link_9.GIF"
-          item "http://id774.net/images/link_10.tiff"
-          item "http://id774.net/images/link_11.TIFF"
+          item "https://id774.net/images/link_8.gif"
+          item "https://id774.net/images/link_9.GIF"
+          item "https://id774.net/images/link_10.tiff"
+          item "https://id774.net/images/link_11.TIFF"
         }
       }
     )
@@ -197,17 +197,17 @@ describe Automatic::Plugin::StorePermalink do
     instance = Automatic::Plugin::StorePermalink.new({"db" => @db_filename},
       AutomaticSpec.generate_pipeline {
         feed {
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_1.jpg"
-          item "http://id774.net/images/link_3.JPG"
-          item "http://id774.net/images/link_4_2.png"
-          item "http://id774.net/images/link_5_2.jpeg"
-          item "http://id774.net/images/link_6.PNG"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_1.jpg"
+          item "https://id774.net/images/link_3.JPG"
+          item "https://id774.net/images/link_4_2.png"
+          item "https://id774.net/images/link_5_2.jpeg"
+          item "https://id774.net/images/link_6.PNG"
           item nil
-          item "http://id774.net/images/link_8.gif"
-          item "http://id774.net/images/link_9.GIF"
-          item "http://id774.net/images/link_10.tiff"
-          item "http://id774.net/images/link_11.TIFF"
+          item "https://id774.net/images/link_8.gif"
+          item "https://id774.net/images/link_9.GIF"
+          item "https://id774.net/images/link_10.tiff"
+          item "https://id774.net/images/link_11.TIFF"
         }
       }
     )

--- a/spec/plugins/subscription/link_spec.rb
+++ b/spec/plugins/subscription/link_spec.rb
@@ -36,7 +36,7 @@ describe Automatic::Plugin::SubscriptionLink do
     subject {
       Automatic::Plugin::SubscriptionLink.new(
         { 'urls' => [
-            "http://id774.net"],
+            "https://id774.net"],
           'interval' => 1
         }
       )
@@ -49,7 +49,7 @@ describe Automatic::Plugin::SubscriptionLink do
     subject {
       Automatic::Plugin::SubscriptionLink.new(
         { 'urls' => [
-            "http://id774.net"],
+            "https://id774.net"],
           'interval' => 2,
           'retry' => 3
         }

--- a/spec/plugins/subscription/xml_spec.rb
+++ b/spec/plugins/subscription/xml_spec.rb
@@ -36,7 +36,7 @@ describe Automatic::Plugin::SubscriptionXml do
     subject {
       Automatic::Plugin::SubscriptionXml.new(
         { 'urls' => [
-            "http://id774.net"]
+            "https://id774.net"]
         }
       )
     }
@@ -48,7 +48,7 @@ describe Automatic::Plugin::SubscriptionXml do
     subject {
       Automatic::Plugin::SubscriptionXml.new(
         { 'urls' => [
-            "http://id774.net/test/xml/data"],
+            "https://id774.net/test/xml/data"],
           'interval' => 1
         }
       )
@@ -61,7 +61,7 @@ describe Automatic::Plugin::SubscriptionXml do
     subject {
       Automatic::Plugin::SubscriptionXml.new(
         { 'urls' => [
-            "http://id774.net/test/xml/data"],
+            "https://id774.net/test/xml/data"],
           'interval' => 2,
           'retry' => 3
         }

--- a/test/integration/test_xml2fluentd.yml
+++ b/test/integration/test_xml2fluentd.yml
@@ -9,7 +9,7 @@ plugins:
   - module: SubscriptionXml
     config:
       urls:
-        - http://id774.net/test/xml/data
+        - https://id774.net/test/xml/data
 
   - module: ProvideFluentd
     config:


### PR DESCRIPTION
## Summary

- The prior HTTPS migration of README, LICENSE, and source header `id774.net` links has already been merged into `master`.
- This PR mechanically updates the remaining `id774.net` URLs found in test fixtures and expected values (9 files) from `http://id774.net` to `https://id774.net`.
- Both input and expected values were updated together wherever the same URL appeared in both, so no test's actual result changed.
- HTTP fixtures pointing to hosts other than `id774.net` (e.g. `example.com`, `github.com`, `matome.naver.jp`), and tests that deliberately exercise HTTP/HTTPS scheme-matching behavior (e.g. "when the link is https and the record is anchored on http"), were intentionally left unchanged.
- No changes to production code, version, documentation, or dependencies.

## Changed files

- `spec/plugins/filter/image_spec.rb`
- `spec/plugins/store/permalink_spec.rb`
- `spec/plugins/subscription/xml_spec.rb`
- `spec/plugins/subscription/link_spec.rb`
- `spec/plugins/filter/absolute_uri_spec.rb`
- `spec/plugins/filter/full_feed_spec.rb`
- `spec/plugins/provide/fluentd_spec.rb`
- `spec/plugins/store/file_spec.rb`
- `test/integration/test_xml2fluentd.yml`

## Validation (actual results)

- Remaining old `http://id774.net` URLs in the 9 target files: 0 — PASS
- Changes outside the 9 target files: 0 — PASS
- Non-`id774.net` HTTP URLs changed: 0 — PASS
- HTTP/HTTPS scheme-matching test semantics unchanged: PASS
- Production code changes: 0 — PASS
- Version changes: 0 — PASS
- Documentation changes: 0 — PASS
- Dependency changes: 0 — PASS
- `git diff --check`: PASS (0 whitespace errors)
- `bundle exec rake`: PASS (423 examples, 0 failures; pre-existing optional-plugin specs were skipped per existing policy due to missing optional gems, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)